### PR TITLE
feat(tea): InlineRenderer, flaky test fixes, version-agnostic docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.4] - 2026-02-24
+
+### Added
+
+- **tea**: InlineRenderer for non-alt-screen rendering — per-line diffing, ANSI-preserving width truncation, height clipping, thread-safe
+- **tea**: InlineRenderer integration in Program — lazy init on first `View()`, automatic `WindowSizeMsg` forwarding, `Repaint()` on `Resume()`
+- **tea**: 35 new InlineRenderer tests (99.4% coverage) covering rendering, diffing, resize, repaint, truncation, concurrency, ANSI handling, Unicode/CJK width
+
+### Fixed
+
+- **tea**: Fix 6 flaky inputReader tests on Windows — replace racy `inputReaderRunning` checks with race-free `inputReaderGeneration` counter
+- **tea**: Remove all `t.Skip("flaky on Windows")` from `exec_process_test.go` (4 tests) and `suspend_resume_test.go` (2 tests)
+
+### Changed
+
+- **docs**: Make all README.md files version-agnostic (no more hardcoded versions, week references, or coverage percentages)
+
+---
+
 ## [0.2.3] - 2026-02-06 (PATCH)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![Release](https://img.shields.io/github/v/release/phoenix-tui/phoenix?include_prereleases)](https://github.com/phoenix-tui/phoenix/releases)
 [![CI](https://github.com/phoenix-tui/phoenix/actions/workflows/test.yml/badge.svg)](https://github.com/phoenix-tui/phoenix/actions)
 [![Go Report Card](https://goreportcard.com/badge/github.com/phoenix-tui/phoenix)](https://goreportcard.com/report/github.com/phoenix-tui/phoenix)
-[![Coverage](https://img.shields.io/badge/coverage-91.8%25-brightgreen)](https://github.com/phoenix-tui/phoenix)
 [![License](https://img.shields.io/github/license/phoenix-tui/phoenix)](https://github.com/phoenix-tui/phoenix/blob/main/LICENSE)
 [![GoDoc](https://pkg.go.dev/badge/github.com/phoenix-tui/phoenix.svg)](https://pkg.go.dev/github.com/phoenix-tui/phoenix)
 
@@ -16,39 +15,38 @@
 
 > Next-generation Terminal User Interface framework for Go
 
-**Status**: ✅ v0.2.3 STABLE
 **Organization**: [github.com/phoenix-tui](https://github.com/phoenix-tui)
 **Go Version**: 1.25+
-**Test Coverage**: **91.8%** (Excellent across all modules)
-**Performance**: 29,000 FPS (489x faster than 60 FPS target)
-**API Quality**: **9/10** (Validated against Go 2025 best practices)
-**Latest**: Pipe-based stdin cancellation for MSYS/mintty, double-close protection
 
 ## Why Phoenix?
 
 Phoenix rises from the ashes of legacy TUI frameworks, solving critical problems:
 
-- ✅ **Perfect Unicode/Emoji support** - No more layout bugs
-- ✅ **10x Performance** - Differential rendering, caching, zero allocations
-- ✅ **DDD Architecture** - Clean, testable, extendable
-- ✅ **Rich Component Library** - Everything you need out of the box
-- ✅ **Public Cursor API** - Full control for shell applications
-- ✅ **Easy Migration from Charm** - [Comprehensive migration guide](docs/user/MIGRATION_GUIDE.md) included
+- **Perfect Unicode/Emoji support** - No more layout bugs
+- **High Performance** - Differential rendering, caching, zero allocations
+- **DDD Architecture** - Clean, testable, extendable
+- **Rich Component Library** - Everything you need out of the box
+- **Public Cursor API** - Full control for shell applications
+- **Inline & Alt-Screen rendering** - Per-line diffing without alt screen, or full-screen mode
+- **TTY Control** - Run editors, shells, and other processes from within your TUI
+- **Easy Migration from Charm** - [Comprehensive migration guide](docs/user/MIGRATION_GUIDE.md) included
 
 ## Libraries
 
-Phoenix is a modular framework with 8 independent libraries:
+Phoenix is a modular framework with 10 independent libraries:
 
-- **phoenix/core** ✅ - Terminal primitives, Unicode/Emoji support (CORRECT width calculation!)
-- **phoenix/style** ✅ - CSS-like styling + **Theme System** (4 presets, runtime switching)
-- **phoenix/layout** ✅ - Flexbox & grid layout (Box model, responsive sizing)
-- **phoenix/tea** ✅ - Elm Architecture + **TTY Control** (run vim, shells, job control)
-- **phoenix/render** ✅ - High-performance differential renderer (29,000 FPS!)
-- **phoenix/components** ✅ - 10 UI components:
-  - TextArea | TextInput | List | Viewport | Table | Modal | Progress
-  - **NEW in v0.2.0**: Select, MultiSelect, Confirm, Form (with validation)
-- **phoenix/mouse** ✅ - Mouse events (click, scroll, drag-drop, right-click support)
-- **phoenix/clipboard** ✅ - Cross-platform clipboard (OSC 52 for SSH)
+| Library | Description |
+|---------|-------------|
+| **[phoenix/core](core/)** | Terminal primitives, Unicode/Emoji support (correct width calculation) |
+| **[phoenix/terminal](terminal/)** | ANSI terminal operations, raw mode, capabilities |
+| **[phoenix/style](style/)** | CSS-like styling + Theme System (presets, runtime switching) |
+| **[phoenix/layout](layout/)** | Flexbox & grid layout (box model, responsive sizing) |
+| **[phoenix/tea](tea/)** | Elm Architecture + TTY Control + Inline Renderer |
+| **[phoenix/render](render/)** | High-performance differential renderer |
+| **[phoenix/components](components/)** | UI components: TextArea, TextInput, List, Viewport, Table, Modal, Progress, Select, MultiSelect, Confirm, Form |
+| **[phoenix/mouse](mouse/)** | Mouse events (click, scroll, drag-drop, right-click) |
+| **[phoenix/clipboard](clipboard/)** | Cross-platform clipboard (OSC 52 for SSH) |
+| **[phoenix/testing](testing/)** | Mock terminal and test utilities |
 
 ## Installation
 
@@ -123,7 +121,6 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 }
 
 func (m Model) View() string {
-    // Use Phoenix convenience API for styling
     style := phoenix.NewStyle().Foreground("#00FF00").Bold()
     return style.Render(fmt.Sprintf("Count: %d\n", m.count))
 }
@@ -185,100 +182,15 @@ func main() {
 ## Documentation
 
 - **[MIGRATION_GUIDE.md](docs/user/MIGRATION_GUIDE.md)** - Migrate from Charm ecosystem (Bubbletea/Lipgloss/Bubbles)
-- **[ROADMAP.md](ROADMAP.md)** - Public roadmap (milestones, progress, dates)
 - **[CHANGELOG.md](CHANGELOG.md)** - Version history and changes
+- **[ROADMAP.md](ROADMAP.md)** - Public roadmap
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** - Development guide
 - **[GoDoc](https://pkg.go.dev/github.com/phoenix-tui/phoenix)** - API reference for all modules
 
-## Development Status
-
-| Library | Status | Coverage | Week | Notes |
-|---------|--------|----------|------|-------|
-| **core** | ✅ v0.1.0 | 98.4% | 3-4 | Unicode/Emoji CORRECT! |
-| **style** | ✅ v0.1.0 | 90%+ | 5-6 | CSS-like styling |
-| **tea** | ✅ v0.1.0 | 95.7% | 7-8 | Elm Architecture |
-| **layout** | ✅ v0.1.0 | 97.9% | 9-10 | Flexbox + Box model |
-| **components** | ✅ v0.1.0 | 94.5% | 11-12 | 6 universal components |
-| **render** | ✅ v0.1.0 | **91.7%** | 13-14 | 29,000 FPS (489x faster!) |
-| **mouse** | ✅ v0.1.0 | **99.7%** | 16 | 3 critical bugs fixed! |
-| **clipboard** | ✅ v0.1.0 | 82.0% | 16 | Cross-platform + SSH |
-
-### Overall Progress
-
-```
-Phase 1: Foundation     ████████████████████  (10%)  ✅ Weeks 1-2
-Phase 2: Core Libs      ████████████████████  (30%)  ✅ Weeks 3-8
-Phase 3: Components     ████████████████████  (20%)  ✅ Weeks 9-12
-Phase 4: Advanced       ████████████████████  (15%)  ✅ Weeks 13-16
-Phase 5: Launch         ████████████████████  (25%)  ✅ Week 20 - API Polish
-                        ══════════════════════
-                        Progress: 100% (v0.1.0 STABLE!)
-```
-
-**v0.1.0 STABLE RELEASED**: API Quality 9/10, 91.8% coverage, 29,000 FPS, zero value docs complete
-
-### Completed Features
-
-**Week 3-4: phoenix/core**
-- Terminal primitives (ANSI, raw mode, capabilities)
-- Unicode/Emoji width calculation (CORRECT - fixes Charm bug!)
-- Grapheme cluster support (👋🏽 = 1 cluster, 2 cells)
-- 98.4% test coverage
-
-**Week 5-6: phoenix/style**
-- CSS-like styling (bold, italic, colors)
-- Border/padding/margin support
-- 8-stage rendering pipeline
-- Fluent builder API
-- 90%+ test coverage
-
-**Week 7-8: phoenix/tea**
-- Elm Architecture (Model-Update-View)
-- Type-safe event loop
-- Command system (Quit, Batch, Sequence, Tick)
-- Generic constraints (no interface{} casts!)
-- 95.7% test coverage
-
-**Week 9-10: phoenix/layout**
-- Box model (padding, margin, border, sizing)
-- Flexbox layout (row/column, gap, flex grow/shrink)
-- Responsive sizing
-- 97.9% test coverage (highest!)
-
-**Week 11-12: phoenix/components**
-- **TextInput** (90.0%) - Public cursor API, grapheme-aware, selection, validation
-- **List** (94.7%) - Single/multi selection, filtering, custom rendering
-- **Viewport** (94.5%) - Scrolling, follow mode, large content (10K+ lines)
-- **Table** (92.0%) - Sortable columns, custom cell renderers, navigation
-- **Modal** (96.5%) - Focus trap, buttons, dimming, keyboard shortcuts
-- **Progress** (98.5%) - Bar + 15 spinner styles
-- Average coverage: **94.5%** (exceeds 90% target!)
-
-**Week 13-14: phoenix/render**
-- Differential rendering (virtual buffer)
-- 29,000 FPS achieved (489x faster than 60 FPS target!)
-- Zero allocations in hot paths
-- **91.7% test coverage** (improved from 87.1%)
-
-**Week 16: phoenix/mouse** 🔥
-- All buttons (Left, Right, Middle, WheelUp, WheelDown)
-- Click detection (single/double/triple - automatic!)
-- Drag & drop state tracking
-- Multi-protocol (SGR, X10, URxvt)
-- Comprehensive README (588 lines)
-- **99.7% test coverage** - 6,000+ lines test code
-- **3 critical bugs found and fixed** during coverage sprint!
-
-**Week 16: phoenix/clipboard**
-- Cross-platform (Windows/macOS/Linux)
-- OSC 52 for SSH sessions (auto-detect)
-- Native APIs (user32.dll, pbcopy/pbpaste, xclip/xsel)
-- DDD architecture
-- 82% average test coverage (domain 100%)
-
 ## Key Features
 
-### 1. Perfect Unicode/Emoji Support ✅
+### 1. Perfect Unicode/Emoji Support
+
 **Problem**: Charm's Lipgloss has broken emoji width calculation ([issue #562](https://github.com/charmbracelet/lipgloss/issues/562))
 **Solution**: Phoenix uses grapheme cluster detection with correct East Asian Width (UAX #11)
 
@@ -291,20 +203,22 @@ width := style.Width(text)  // Returns 17 (correct!)
 width := lipgloss.Width(text)  // Returns 19 (wrong!)
 ```
 
-### 2. 10x Performance ✅
-**Benchmark**: 29,000 FPS (489x faster than 60 FPS target)
-**Techniques**: Differential rendering, caching, zero allocations
+### 2. High Performance
 
-### 3. DDD Architecture ✅
+**Techniques**: Differential rendering, virtual buffer, caching, zero allocations on hot paths
+
+### 3. DDD Architecture
+
 ```
 library/
-├── domain/        # Business logic (95%+ coverage)
+├── domain/        # Business logic (highest coverage)
 ├── application/   # Use cases
 ├── infrastructure/ # Technical details
 └── api/           # Public interface
 ```
 
-### 4. Public Cursor API ✅
+### 4. Public Cursor API
+
 **Problem**: Bubbles TextArea has private cursor - syntax highlighting impossible
 **Solution**: Phoenix TextInput exposes `CursorPosition()` and `ContentParts()`
 
@@ -319,89 +233,54 @@ highlighted := syntax.Highlight(before) +
 // cursor is internal field - no access
 ```
 
-### 5. Mouse & Clipboard Support ✅
-**Mouse**: All buttons (Left, Right, Middle, Wheel), drag-drop, click detection
+### 5. TTY Control
+
+Run external processes (vim, shells, pagers) from within your TUI:
+
+```go
+case api.KeyMsg:
+    if msg.String() == "e" {
+        return m, api.ExecProcess("vim", "file.txt")
+    }
+case api.ExecProcessFinishedMsg:
+    // Editor closed, TUI restored automatically
+```
+
+### 6. Inline Rendering
+
+Run without alt screen - per-line diffing renders updates in place:
+
+```go
+p := api.New(myModel) // inline mode by default - no alt screen needed
+```
+
+### 7. Mouse & Clipboard Support
+
+**Mouse**: All buttons (Left, Right, Middle, Wheel), drag-drop, click detection (single/double/triple)
 **Clipboard**: Cross-platform (Windows/macOS/Linux), SSH support (OSC 52)
 
-### 6. Progress Component ✅
-**Available**: Progress Bar + 15 Spinner Styles (Week 11-12, 98.5% coverage)
-**Location**: `github.com/phoenix-tui/phoenix/components/progress/api`
+### 8. Progress Component
 
-Phoenix includes a comprehensive Progress component with both bars and animated spinners:
+Progress bars and 15 animated spinner styles:
 
 ```go
 import progress "github.com/phoenix-tui/phoenix/components/progress/api"
 
-// Progress Bar
-bar := progress.NewBar(100).  // Max value 100
-    SetWidth(40).
-    SetLabel("Downloading").
-    SetValue(65)  // Current progress 65%
-
-// Animated Spinner (15 styles available!)
-spinner := progress.NewSpinner(progress.SpinnerDots).
-    SetLabel("Loading").
-    SetFPS(10)
-
-// Example styles: SpinnerDots, SpinnerLine, SpinnerArrow, SpinnerCircle,
-// SpinnerBounce, SpinnerPulse, SpinnerGrowHorizontal, SpinnerGrowVertical, etc.
+bar := progress.NewBar(100).SetWidth(40).SetLabel("Downloading").SetValue(65)
+spinner := progress.NewSpinner(progress.SpinnerDots).SetLabel("Loading")
 ```
 
-**Features**:
-- Progress bars with customizable width and characters
-- 15 pre-built spinner styles (dots, lines, arrows, circles, bouncing, etc.)
-- Label support for both bars and spinners
-- Configurable FPS for smooth animations
-- 98.5% test coverage
+## Comparison with Charm Ecosystem
 
-**Examples**: See [examples/progress/](examples/progress/) for working demonstrations:
-- `bar_simple.go` - Basic progress bar
-- `bar_styled.go` - Styled progress bar with colors
-- `spinner_simple.go` - Animated spinner
-- `multi_progress.go` - Multiple progress indicators
-
-**Documentation**: See [components/progress/README.md](components/progress/README.md) for full API reference
-
-## What's New in v0.2.1–v0.2.3
-
-**v0.2.3** - Fix `ExecProcessWithTTY` on Windows (defer undid raw mode after Resume)
-
-**v0.2.1** - Pipe-based CancelableReader (fixes stdin race on MSYS2/mintty):
-- Instant `Cancel()` on ALL platforms via os.Pipe relay architecture
-- Double-close protection via `sync.Once`
-- Removed `rivo/uniseg` from core — `uniwidth v0.2.0` handles all width calculation
-- 12 new tests for pipe relay and shutdown safety
-
-**See [CHANGELOG.md](CHANGELOG.md) for full details**
-
-## What's in v0.2.0
-
-**TTY Control System** (Level 1, 1+, 2):
-- Run external processes like vim, nano, shells with full terminal control
-- Suspend/Resume Phoenix TUI while external process runs
-- Job control support (foreground/background process groups)
-- Platform support: Linux, macOS, Windows
-
-**Form Components**:
-- **Select** - Single-choice dropdown with keyboard navigation
-- **MultiSelect** - Multiple-choice selection with checkboxes
-- **Confirm** - Yes/No prompts with customizable buttons
-- **Form** - Complete form system with validation
-
-**Theme System**:
-- 4 built-in presets: Default, Dark, Light, HighContrast
-- Runtime theme switching
-- All 10 components support Theme API
-- Custom theme creation
-
-**See [CHANGELOG.md](CHANGELOG.md) for full v0.2.0 details**
-
-### What's Next?
-
-**v0.3.0** (Future):
-- Signals integration (reactive views - optional, hybrid approach)
-- Animation framework
-- Grid layout enhancements
+| Feature | Phoenix | Charm (Bubbletea/Lipgloss) |
+|---------|---------|---------------------------|
+| Unicode/Emoji | Correct width (UAX #11) | Broken ([#562](https://github.com/charmbracelet/lipgloss/issues/562)) |
+| Type Safety | Generic constraints | `interface{}` casts |
+| Inline Rendering | Per-line diffing | Basic |
+| TTY Control | ExecProcess + Suspend/Resume | ExecProcess only |
+| Cursor API | Public | Private |
+| Architecture | DDD layers | Monolithic |
+| Theme System | Built-in (4 presets) | Manual |
 
 ## Contributing
 
@@ -417,6 +296,4 @@ MIT License - see [LICENSE](LICENSE) file for details
 
 ---
 
-*Rising from the ashes of legacy TUI frameworks* 🔥
-**v0.2.3 STABLE** ⭐
-*API Quality: 9/10 | 91.8% coverage | 29,000 FPS | ExecProcessWithTTY fixed!*
+*Rising from the ashes of legacy TUI frameworks*

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -52,7 +52,7 @@ benchmarks/
 │   ├── README.md            # Detailed results documentation
 │   ├── current/             # Latest benchmark runs
 │   ├── baseline/            # Stable baseline for comparisons
-│   └── history/             # Release milestones (v0.1.0-beta.3, etc.)
+│   └── history/             # Release milestones
 └── scripts/                  # Automation scripts
     ├── run_benchmarks.sh    # Run all benchmarks
     ├── compare.sh           # Compare current vs baseline
@@ -61,7 +61,7 @@ benchmarks/
 
 ---
 
-## 🚀 Current Performance (v0.1.0-beta.3)
+## 🚀 Current Performance
 
 ### Render Performance
 
@@ -87,7 +87,7 @@ benchmarks/
 | Code Editor | 117 µs/op |
 | Small UI Change | 28 µs/op |
 
-Full results: [`results/history/v0.1.0-beta.3/summary.md`](results/history/v0.1.0-beta.3/summary.md)
+Full results: see `results/history/` for per-release summaries.
 
 ---
 
@@ -222,7 +222,7 @@ go test -bench=. -memprofile=mem.prof
 
 - [Go Benchmark Documentation](https://pkg.go.dev/testing#hdr-Benchmarks)
 - [benchstat tool](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat)
-- [Phoenix Performance Report](results/history/v0.1.0-beta.3/summary.md)
+- [Phoenix Performance Reports](results/history/)
 
 ---
 
@@ -242,5 +242,4 @@ A: Run benchmarks, save results, and open issue with before/after comparison.
 
 ---
 
-**Last Updated**: 2025-10-23
-**Baseline**: v0.1.0-beta.3
+*Phoenix TUI - Performance Benchmarks*

--- a/benchmarks/results/README.md
+++ b/benchmarks/results/README.md
@@ -19,9 +19,7 @@ results/
 │   └── version.txt       # Baseline version info
 │
 └── history/              # Milestone results (releases only)
-    ├── v0.1.0-beta.1/
-    ├── v0.1.0-beta.2/
-    └── v0.1.0-beta.3/    # Each contains:
+    └── <version>/        # Each release contains:
         ├── render.txt         # Full results
         ├── core-unicode.txt
         └── summary.md         # Human-readable summary
@@ -97,7 +95,7 @@ bash benchmarks/scripts/set_baseline.sh
 3. **Save to history** (for releases):
    ```bash
    # Copy results to history
-   VERSION="v0.1.0-beta.3"
+   VERSION="vX.Y.Z"  # Replace with actual version
    mkdir -p benchmarks/results/history/$VERSION
    cp benchmarks/results/current/*.txt benchmarks/results/history/$VERSION/
 
@@ -198,5 +196,4 @@ For CI/CD integration, see `.github/workflows/` (when added).
 
 ---
 
-**Last Updated**: 2025-10-23
-**Current Baseline**: v0.1.0-beta.3
+*Phoenix TUI - Benchmark Results*

--- a/clipboard/README.md
+++ b/clipboard/README.md
@@ -376,15 +376,6 @@ func (m *TextInputModel) handlePaste() tea.Cmd {
 
 ## Roadmap
 
-### v0.1.0 (Current)
-- [x] Cross-platform clipboard support
-- [x] OSC 52 implementation
-- [x] Native platform providers (Windows, macOS, Linux)
-- [x] Auto-detection and fallback
-- [x] Domain-driven architecture
-- [x] 90%+ test coverage
-- [x] Examples and documentation
-
 ### Future Enhancements
 - [ ] Rich text format support
 - [ ] Image clipboard support

--- a/clipboard/examples/image-clipboard/README.md
+++ b/clipboard/examples/image-clipboard/README.md
@@ -112,7 +112,7 @@ The `ImageCodec` is a domain service providing:
 
 ### Test Coverage
 
-The ImageCodec service has **95.7% test coverage**, exceeding the 90% target.
+The ImageCodec service has extensive test coverage, exceeding project targets.
 
 ## Clipboard Integration (Future)
 

--- a/components/README.md
+++ b/components/README.md
@@ -2,9 +2,7 @@
 
 Rich, reusable TUI components for Phoenix Framework with DDD architecture, type safety, and comprehensive testing.
 
-**Status**: ✅ Week 11-12 Complete + v0.1.0-beta.2 (TextArea Cursor Control)
 **Module**: `github.com/phoenix-tui/phoenix/components`
-**Coverage**: 94.5% average across all components
 **License**: MIT (planned)
 
 ---
@@ -14,13 +12,13 @@ Rich, reusable TUI components for Phoenix Framework with DDD architecture, type 
 Phoenix Components is a rich library of terminal UI widgets built on top of Phoenix/tea (Elm Architecture). Each component follows Domain-Driven Design principles with clear separation between business logic, presentation, and infrastructure.
 
 **Features**:
-- ✅ **6 Production-Ready Components** - Input, TextArea, List, Viewport, Table, Modal, Progress
-- ✅ **DDD Architecture** - Domain layer with 90%+ coverage
-- ✅ **Type-Safe** - Generic constraints for compile-time safety
-- ✅ **Fluent API** - Chainable method calls for easy styling
-- ✅ **Unicode-Aware** - Perfect CJK and emoji support
-- ✅ **Highly Tested** - 94.5% average coverage
-- ✅ **Zero External TUI Dependencies** - Built from scratch
+- **7 Production-Ready Components** - Input, TextArea, List, Viewport, Table, Modal, Progress
+- **DDD Architecture** - Domain layer with high test coverage
+- **Type-Safe** - Generic constraints for compile-time safety
+- **Fluent API** - Chainable method calls for easy styling
+- **Unicode-Aware** - Perfect CJK and emoji support
+- **Extensive Test Suite** - High coverage across all components
+- **Zero External TUI Dependencies** - Built from scratch
 
 ---
 
@@ -28,7 +26,6 @@ Phoenix Components is a rich library of terminal UI widgets built on top of Phoe
 
 ### 1. Input - Single-Line Text Input
 **Module**: `github.com/phoenix-tui/phoenix/components/input`
-**Coverage**: 90.0%
 
 Single-line text input with placeholder, validation, password mode, and character filtering.
 
@@ -60,9 +57,8 @@ field := input.New(40).
 
 ---
 
-### 2. TextArea - Multiline Text Editor ⭐ NEW in v0.1.0-beta.2
+### 2. TextArea - Multiline Text Editor
 **Module**: `github.com/phoenix-tui/phoenix/components/input/textarea`
-**Coverage**: 83.4% (domain model)
 
 Multiline text editor with advanced cursor control, perfect for shells, code editors, and chat interfaces.
 
@@ -89,7 +85,7 @@ ta := textarea.New().
     })
 ```
 
-**Features** (v0.1.0-beta.2):
+**Features**:
 - ✅ **SetCursorPosition(row, col)** - Programmatic cursor positioning
 - ✅ **OnMovement(validator)** - Movement validation (protect areas)
 - ✅ **OnCursorMoved(handler)** - Cursor movement observer
@@ -113,7 +109,6 @@ ta := textarea.New().
 
 ### 3. List - Scrollable Item List
 **Module**: `github.com/phoenix-tui/phoenix/components/list`
-**Coverage**: 94.7%
 
 Scrollable list with filtering, multi-select, and custom item rendering.
 
@@ -139,9 +134,8 @@ l := list.New([]string{"Item 1", "Item 2", "Item 3"}).
 
 ---
 
-### 4. Viewport - Scrollable Content Area ⭐ Enhanced: Wheel Scrolling Configuration (Week 15)
+### 4. Viewport - Scrollable Content Area
 **Module**: `github.com/phoenix-tui/phoenix/components/viewport`
-**Coverage**: 98.7%
 
 Scrollable content area for displaying long text, logs, or chat history with configurable wheel scrolling and drag support.
 
@@ -159,25 +153,24 @@ p := tea.New(model, tea.WithMouseAllMotion[Model]())
 ```
 
 **Features**:
-- ✅ **Configurable Wheel Scrolling** (NEW!) - Adjust scroll speed (1-10+ lines per tick)
-- ✅ **Drag Scrolling** - Click and drag to scroll (natural touch behavior)
-- ✅ Mouse wheel support (default: 3 lines per tick, customizable)
-- ✅ Keyboard navigation (arrows, page up/down, Home/End, Ctrl+U/D)
-- ✅ Dynamic content updates with FollowMode (tail -f style)
-- ✅ Precise scroll position control (SetYOffset)
-- ✅ Line wrapping and truncation support
-- ✅ Bounds checking (won't scroll past content)
-- ✅ Immutable operations (functional updates)
+- **Configurable Wheel Scrolling** - Adjust scroll speed (1-10+ lines per tick)
+- **Drag Scrolling** - Click and drag to scroll (natural touch behavior)
+- Mouse wheel support (default: 3 lines per tick, customizable)
+- Keyboard navigation (arrows, page up/down, Home/End, Ctrl+U/D)
+- Dynamic content updates with FollowMode (tail -f style)
+- Precise scroll position control (SetYOffset)
+- Line wrapping and truncation support
+- Bounds checking (won't scroll past content)
+- Immutable operations (functional updates)
 
-**Wheel Scrolling Configuration** (Week 15 Day 5-6):
+**Wheel Scrolling Configuration**:
 - `SetWheelScrollLines(lines int)` - Configure scroll amount per wheel tick
 - Default: 3 lines per tick
 - Recommended: 1-10 lines for smooth scrolling
 - Minimum enforced: 1 line (values < 1 are clamped)
 - Dynamic adjustment: Change scroll speed on the fly
-- 12 comprehensive tests (98.7% coverage)
 
-**Drag Scrolling** (Week 15 Day 3-4):
+**Drag Scrolling**:
 - Left mouse button drag to scroll
 - Natural direction: drag down → content scrolls up
 - Works with 10,000+ lines smoothly
@@ -191,7 +184,6 @@ p := tea.New(model, tea.WithMouseAllMotion[Model]())
 
 ### 5. Table - Data Table with Sorting
 **Module**: `github.com/phoenix-tui/phoenix/components/table`
-**Coverage**: 92.0%
 
 Data table with columns, rows, sorting, and pagination.
 
@@ -226,7 +218,6 @@ t := table.New().
 
 ### 6. Modal - Dialog Boxes
 **Module**: `github.com/phoenix-tui/phoenix/components/modal`
-**Coverage**: 96.5%
 
 Modal dialogs for confirmations, alerts, and user prompts.
 
@@ -258,7 +249,6 @@ m := modal.New().
 
 ### 7. Progress - Progress Bars and Spinners
 **Module**: `github.com/phoenix-tui/phoenix/components/progress`
-**Coverage**: 98.5%
 
 Progress indicators for loading states and long-running operations.
 
@@ -404,22 +394,22 @@ All Phoenix components follow Domain-Driven Design:
 
 ```
 component/
-├── domain/          # Business logic (95%+ coverage)
+├── domain/          # Business logic
 │   ├── model/      # Entities and aggregates
 │   ├── value/      # Value objects
 │   └── service/    # Domain services
-├── infrastructure/  # Technical implementation (80%+ coverage)
+├── infrastructure/  # Technical implementation
 │   ├── renderer/   # View rendering
 │   └── keybindings/# Keyboard handling
-└── api/            # Public interface (90%+ coverage)
+└── api/            # Public interface
     └── component.go
 ```
 
 **Why DDD?**
-- ✅ Pure business logic in domain (easy to test)
-- ✅ Infrastructure swappable (ANSI → native → web?)
-- ✅ API layer provides fluent interface
-- ✅ 90%+ test coverage consistently achieved
+- Pure business logic in domain (easy to test)
+- Infrastructure swappable (ANSI -> native -> web?)
+- API layer provides fluent interface
+- High test coverage consistently achieved
 
 ---
 
@@ -485,49 +475,22 @@ go test -cover ./...
 go test ./input/... -v
 ```
 
-**Coverage by Component**:
-| Component | API | Domain | Infrastructure | Overall |
-|-----------|-----|--------|---------------|---------|
-| Input | 56.9% | 92.2% | 100.0% | 90.0% |
-| TextArea | 56.2% | 83.4% | 77.4% | 73.2% |
-| List | ~60% | ~95% | ~85% | 94.7% |
-| Viewport | ~60% | ~95% | 100.0% | 98.7% | ⭐ Enhanced Week 15 (Wheel Config)
-| Table | ~60% | ~93% | ~90% | 92.0% |
-| Modal | ~65% | ~98% | ~95% | 96.5% |
-| Progress | 97.4% | 100.0% | 100.0% | 98.5% |
-
-**Average**: 94.5% (exceeds 90% target!)
-**Viewport**: 98.7% with drag + wheel scrolling (26 comprehensive tests)
+All components have extensive test coverage across API, domain, and infrastructure layers.
 
 ---
 
-## Roadmap
+## Future Components
 
-### Completed (Week 11-12)
-- ✅ Input component (single-line text)
-- ✅ TextArea component (multiline editor)
-- ✅ List component (scrollable items)
-- ✅ Viewport component (scrollable content)
-- ✅ Table component (data tables)
-- ✅ Modal component (dialogs)
-- ✅ Progress component (bars/spinners)
-
-### v0.1.0-beta.2 (Released 2025-10-20)
-- ✅ TextArea cursor control API
-- ✅ Linter cleanup (204 issues → 0)
-- ✅ Go 1.21+ compatibility
-- ✅ OSS best practices
-
-### Future (v0.2.0+)
-- 🚧 Form component (validation, submission)
-- 🚧 Tree component (hierarchical data)
-- 🚧 Menu component (dropdowns, context menus)
-- 🚧 Tabs component (multi-panel views)
-- 🚧 Chart component (graphs, plots)
-- 🚧 File picker component
-- 🚧 Calendar component
+- Form component (validation, submission)
+- Tree component (hierarchical data)
+- Menu component (dropdowns, context menus)
+- Tabs component (multi-panel views)
+- Chart component (graphs, plots)
+- File picker component
+- Calendar component
 
 ### Long-term
+
 - Theme system with presets
 - Animation framework
 - Accessibility improvements
@@ -541,13 +504,10 @@ go test ./input/... -v
 |---------|-------------------|---------|
 | Architecture | ✅ DDD (testable) | ⚠️ Monolithic |
 | Type Safety | ✅ Generic constraints | ⚠️ interface{} |
-| Test Coverage | ✅ 94.5% average | ⚠️ Variable |
-| Unicode Support | ✅ Perfect (CJK/emoji) | ❌ Broken ([lipgloss#562](https://github.com/charmbracelet/lipgloss/issues/562)) |
-| API Stability | ⚠️ Beta (v0.1.0-beta.2) | ⚠️ Breaking changes |
-| Dependencies | ✅ Zero external TUI deps | ⚠️ Charm ecosystem |
-| Component Count | ✅ 7 components | ✅ 10+ components |
-| Maturity | ⚠️ Beta (Week 11-12/20) | ✅ Battle-tested |
-| Migration Path | 🚧 Planned (Week 17-18) | N/A |
+| Test Coverage | High across all components | Variable |
+| Unicode Support | Perfect (CJK/emoji) | Broken ([lipgloss#562](https://github.com/charmbracelet/lipgloss/issues/562)) |
+| Dependencies | Zero external TUI deps | Charm ecosystem |
+| Component Count | 7 components | 10+ components |
 
 **Why Phoenix Components?**
 - Modern DDD architecture (clean, testable)
@@ -588,4 +548,4 @@ MIT (planned)
 
 ---
 
-*Built with ❤️ using Domain-Driven Design and Modern Go*
+*Built with Domain-Driven Design and Modern Go*

--- a/components/input/README.md
+++ b/components/input/README.md
@@ -11,7 +11,7 @@
 - **Validation hooks** - Custom validation with clear error states
 - **Extensible keybindings** - Add your own key handlers
 - **Immutable design** - All operations return new instances
-- **High test coverage** - 95%+ domain, 100% API
+- **High test coverage** - Extensive domain and API coverage
 
 ## Installation
 
@@ -266,7 +266,7 @@ customRender := before + "[" + at + "]" + after  // Render cursor as brackets
 
 See: `examples/cursor_api/main.go`
 
-## How gosh Will Use TextInput (Week 17-18)
+## How gosh Will Use TextInput
 
 TextInput is **universal** - gosh will wrap it in `ShellInput` with shell-specific features:
 
@@ -314,13 +314,13 @@ func (s *ShellInput) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 ```
 input/
-├── domain/              # Pure business logic (95%+ coverage)
+├── domain/              # Pure business logic
 │   ├── model/          # TextInput aggregate root
 │   ├── value/          # Cursor, Selection value objects
 │   └── service/        # CursorMovement, Validation services
-├── infrastructure/      # Technical implementation (90%+ coverage)
+├── infrastructure/      # Technical implementation
 │   └── keybindings.go  # Default and custom key handlers
-├── api/                # Public interface (100% coverage)
+├── api/                # Public interface
 │   └── input.go        # Fluent API, tea.Model integration
 └── examples/           # Usage demonstrations
     ├── basic.go
@@ -344,12 +344,7 @@ go test ./...
 # Run with coverage
 go test -cover ./...
 
-# Expected coverage:
-# domain/model:  95%+
-# domain/value:  100%
-# domain/service: 95%+
-# infrastructure: 90%+
-# api:           100%
+# High coverage across all layers
 ```
 
 ## Comparison with Bubbles textinput
@@ -364,7 +359,7 @@ go test -cover ./...
 | Custom keybindings | ✅ KeyBindingHandler interface | ⚠️ Override entire Update() |
 | Scrolling | ✅ Horizontal scrolling | ✅ Similar |
 | Architecture | ✅ DDD with clear layers | ⚠️ Monolithic |
-| Test coverage | ✅ 95%+ | ⚠️ Lower |
+| Test coverage | ✅ High | ⚠️ Lower |
 
 **Key differentiator:** Public cursor API enables applications to:
 - Customize cursor rendering (shell prompts, syntax highlighting)
@@ -397,7 +392,7 @@ value := input.Value()
 - `Focused(bool)` instead of `Focus()/Blur()`
 - `Value()` instead of `Value()` (same!)
 
-## Future Enhancements (Post v0.1.0)
+## Future Enhancements
 
 - **Styling integration** - Full phoenix/style support
 - **Multi-line mode** - Textarea variant
@@ -416,7 +411,4 @@ Apache-2.0 (same as Phoenix TUI Framework)
 
 ---
 
-**Status:** ✅ Week 11 Day 1-3 Complete (v0.1.0-alpha)
-**Coverage:** Domain 95%+, API 100%
 **Examples:** 4 complete (basic, validated, styled, cursor_api)
-**Next:** Week 11 Day 4-7 - List, Viewport, Table components

--- a/components/input/docs/textarea/README.md
+++ b/components/input/docs/textarea/README.md
@@ -304,9 +304,7 @@ Run tests with coverage:
 go test ./... -cover
 ```
 
-Current coverage:
-- Domain layer: **24.1%** (expanding to 95%+ target)
-- Overall: **Expanding**
+Run the coverage report to see current results.
 
 ---
 
@@ -373,4 +371,4 @@ Part of Phoenix TUI Framework. See main project LICENSE.
 ---
 
 *Built for GoSh Classic mode migration.*
-*Part of Phoenix TUI Framework v0.1.0-alpha*
+*Part of Phoenix TUI Framework*

--- a/components/list/README.md
+++ b/components/list/README.md
@@ -11,7 +11,7 @@ A universal selectable list component for Phoenix TUI Framework. Build file pick
 - **Scrolling** - Automatic viewport scrolling for long lists
 - **Immutable API** - All operations return new instances (follows Elm Architecture)
 - **Type-Safe** - Fully typed with Go generics support
-- **Well-Tested** - 94.7% test coverage
+- **Well-Tested** - High test coverage
 
 ## Installation
 
@@ -271,7 +271,7 @@ list/
 1. **Rich Domain Models** - Business logic encapsulated in domain models, not anemic data structures
 2. **Immutability** - All operations return new instances following Elm Architecture
 3. **Type Safety** - Leverage Go generics for compile-time safety
-4. **Testability** - 94.7% test coverage (domain layer 97%+)
+4. **Testability** - High test coverage across all layers
 5. **Zero External Dependencies** - Only depends on `phoenix/tea` for Elm Architecture
 
 ## How gosh Will Use This
@@ -314,21 +314,14 @@ go test ./... -coverprofile=coverage.out
 go tool cover -html=coverage.out
 ```
 
-### Coverage
-
-- **Overall**: 94.7%
-- **domain/model**: 97.1%
-- **domain/service**: 98.0%
-- **domain/value**: 100%
-- **infrastructure**: 100%
-- **api**: 85.9%
+High test coverage across all layers (domain, infrastructure, API).
 
 ## Contributing
 
 Phoenix TUI Framework follows strict quality standards:
 
 - **DDD First** - Rich domain models with behavior
-- **90%+ Test Coverage** - Especially domain layer (95%+)
+- **High Test Coverage** - Especially domain layer
 - **Immutable API** - All operations return new instances
 - **Type Safety** - Use Go 1.25+ features
 - **Documentation** - Clear examples and API docs
@@ -344,8 +337,4 @@ MIT License - See LICENSE file for details
 - [phoenix/layout](../../layout) - Box Model & Flexbox layout
 - [phoenix/core](../../core) - Terminal primitives & Unicode
 
-## Version
-
-Current: v0.1.0-alpha (Week 11 Complete)
-
-Phoenix TUI Framework is under active development. API may change before v1.0.0 release.
+Phoenix TUI Framework is under active development. API may change before a stable release.

--- a/components/modal/README.md
+++ b/components/modal/README.md
@@ -13,11 +13,7 @@ Universal modal/overlay component for Phoenix TUI Framework.
 - **Background dimming** - Improves UX by making modal stand out
 - **Immutable API** - Fluent interface with immutable operations
 - **Type-safe** - Full type safety with Go 1.25+ generics
-- **High test coverage** - 96.5% coverage
-
-## Status
-
-**Week 12 Day 3-4 COMPLETE** - Production-ready, universal component.
+- **High test coverage** - Extensive coverage across all layers
 
 ## Installation
 
@@ -349,13 +345,13 @@ Phoenix Modal follows Domain-Driven Design (DDD):
 
 ```
 modal/
-├── domain/           # Business logic (95%+ coverage)
+├── domain/           # Business logic
 │   ├── model/       # Rich domain models (Button, Modal)
 │   ├── value/       # Value objects (Position, Size)
 │   └── service/     # Domain services (LayoutService)
-├── infrastructure/   # Technical implementation (100% coverage)
+├── infrastructure/   # Technical implementation
 │   └── keybindings.go
-├── api/             # Public interface (94.4% coverage)
+├── api/             # Public interface
 │   └── modal.go     # Fluent API + tea.Model
 └── examples/        # Example applications
 ```
@@ -370,7 +366,7 @@ modal/
 
 ## Use Cases
 
-### 1. Confirmation Dialogs (gosh - Week 17-18)
+### 1. Confirmation Dialogs
 
 ```go
 // Ask user before executing dangerous command
@@ -413,7 +409,7 @@ Font Size: 14
 m := modal.NewWithTitle("Settings", settingsContent).Size(50, 15)
 ```
 
-## Integration with gosh (Week 17-18)
+## Integration with gosh
 
 Phoenix Modal will be used in gosh for:
 
@@ -447,12 +443,7 @@ go test -cover ./...
 go test -v ./...
 ```
 
-Current coverage: **96.5%**
-- Domain model: 100%
-- Domain service: 100%
-- Domain value: 100%
-- Infrastructure: 100%
-- API: 94.4%
+High test coverage across all layers (domain, infrastructure, API).
 
 ## Comparison with Charm Bubbles
 
@@ -464,7 +455,7 @@ Current coverage: **96.5%**
 | Button Navigation | ✅ Yes | ⚠️ Manual |
 | Custom Positioning | ✅ Yes | ❌ No |
 | Background Dimming | ✅ Yes | ❌ No |
-| Test Coverage | ✅ 96.5% | ⚠️ Variable |
+| Test Coverage | ✅ High | ⚠️ Variable |
 | Unicode Correctness | ✅ Yes | ❌ No (lipgloss #562) |
 | Dependencies | ✅ Zero external | ❌ Many |
 
@@ -472,18 +463,12 @@ Current coverage: **96.5%**
 
 Phoenix Modal is part of the Phoenix TUI Framework project.
 
-See [ROADMAP.md](../../docs/dev/ROADMAP.md) for the 20-week development plan.
+See [ROADMAP.md](../../docs/dev/ROADMAP.md) for the development plan.
 
 ## License
 
-Phoenix TUI Framework is open-source (license TBD at v0.1.0 release).
-
-## Version
-
-**v0.1.0-alpha** (Week 12 complete - Week 11-12: Components)
-
-Next: **Progress component** (Week 12 Day 5-7)
+Phoenix TUI Framework is open-source.
 
 ---
 
-**Phoenix TUI Framework** - Building the #1 TUI framework for Go by 2026.
+**Phoenix TUI Framework** - Building the #1 TUI framework for Go.

--- a/components/progress/README.md
+++ b/components/progress/README.md
@@ -309,7 +309,7 @@ The Progress component was designed as a **universal** component and will be use
 - Batch operation tracking
 - Loading states during command execution
 
-Example (gosh Week 17-18):
+Example:
 ```go
 // gosh will use Progress for long-running commands
 type CommandModel struct {
@@ -346,7 +346,7 @@ progress/
 - Rich domain models (behavior + data)
 - Immutability (all operations return new instances)
 - Type safety
-- 80%+ test coverage (domain: 95%+)
+- High test coverage
 
 ## Performance
 
@@ -369,18 +369,9 @@ go test ./components/progress/domain/...
 go test ./components/progress/api/...
 ```
 
-## Version
-
-- **Week 12 Day 5-6** - Initial implementation
-- **Status**: v0.1.0-alpha
-- **Coverage**: 80%+ (domain: 95%+)
-
 ## License
 
 Part of Phoenix TUI Framework
 Organization: phoenix-tui
 Repository: github.com/phoenix-tui/phoenix
 
----
-
-**Next Component**: Week 13-14 - Render (High-performance renderer)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,326 @@
+# Phoenix Architecture
+
+> Technical architecture overview for developers and contributors.
+
+---
+
+## Principles
+
+1. **Correctness** - High test coverage, type safety with generics, property-based testing for Unicode
+2. **Performance** - Sub-16ms render time, zero allocations on hot paths, lazy evaluation
+3. **Modularity** - Clean dependency graph, no cycles, interface-driven, hexagonal architecture
+4. **Developer Experience** - Intuitive APIs, clear error messages, comprehensive examples
+
+---
+
+## Module Dependency Graph
+
+```mermaid
+    graph TD
+    APP(["Your Application"])
+
+    subgraph UI["UI Layer"]
+        CMP["phoenix/components"]
+        CB["phoenix/clipboard"]
+    end
+
+    subgraph Application["Application Layer"]
+        TEA["phoenix/tea"]
+        REN["phoenix/render"]
+    end
+
+    subgraph Domain["Domain Layer"]
+        LAY["phoenix/layout"]
+        STY["phoenix/style"]
+    end
+
+    subgraph Foundation["Foundation Layer"]
+        CORE["phoenix/core"]
+        TERM["phoenix/terminal"]
+        MOU["phoenix/mouse"]
+        TEST["phoenix/testing"]
+    end
+
+    APP --> CMP & TEA & MOU
+
+    CMP --> TEA & LAY & STY
+    CB --> CORE
+
+    TEA --> CORE & TERM
+    REN --> CORE & STY
+
+    LAY --> STY & CORE
+    STY --> CORE
+```
+
+### Dependency Layers
+
+| Layer | Modules | Depends On |
+|-------|---------|------------|
+| **Foundation** | core, terminal, mouse | stdlib only (+ `golang.org/x/sys` for terminal) |
+| **Domain** | style, layout, testing | Foundation |
+| **Application** | render, tea | Foundation + Domain |
+| **UI** | components, clipboard | All lower layers |
+
+**Rule**: Lower layers NEVER depend on higher layers.
+
+---
+
+## DDD Layer Structure
+
+Each Phoenix module follows Domain-Driven Design with clear layer separation:
+
+```
+module/
+├── domain/              # Pure business logic (no external deps)
+│   ├── model/          # Rich domain models with behavior
+│   ├── value/          # Immutable value objects
+│   ├── service/        # Domain services (stateless logic)
+│   └── event/          # Domain events
+│
+├── application/         # Use cases and orchestration
+│   ├── command/        # Command handlers (write operations)
+│   └── query/          # Query handlers (read operations)
+│
+├── infrastructure/      # Technical implementation details
+│   ├── ansi/           # ANSI escape sequences
+│   ├── platform/       # OS-specific code
+│   ├── cache/          # Caching strategies
+│   └── renderer/       # Rendering infrastructure
+│
+└── api/                # Public interface (what users import)
+    └── module.go       # Re-exports, fluent builders, convenience functions
+```
+
+### Layer Rules
+
+- **Domain** - Zero dependencies on infrastructure or external packages. Pure Go. Highest test coverage.
+- **Application** - Orchestrates domain objects. Depends on domain only (via interfaces).
+- **Infrastructure** - Implements interfaces defined in domain/application. ANSI codes, OS calls, I/O.
+- **API** - Thin facade over application layer. Provides ergonomic public types and functions.
+
+### Domain Model Design
+
+Phoenix uses **rich domain models** (not anemic DTOs):
+
+```go
+// Rich model — behavior lives WITH the data
+type Style struct {
+    fg      Color
+    bg      Color
+    bold    bool
+    padding Padding
+}
+
+func (s Style) Bold() Style {
+    s.bold = true
+    return s  // Immutable — returns new instance
+}
+
+func (s Style) Render(text string) string {
+    // Rendering logic encapsulated in the model
+}
+```
+
+**Not** anemic models:
+
+```go
+// Anemic model — data bag with external service
+type Style struct {
+    FG, BG  string
+    Bold    bool
+}
+
+// Logic lives in a separate "service" — violates DDD
+func RenderStyle(s Style, text string) string { ... }
+```
+
+---
+
+## Bounded Contexts
+
+```mermaid
+graph TD
+    subgraph Phoenix["Phoenix Framework"]
+        direction TB
+
+        STY_BC["Styling\n(Bounded Context)"]
+        LAY_BC["Layout\n(Bounded Context)"]
+        REN_BC["Rendering\n(Shared Kernel)"]
+        TEA_BC["Tea\n(Bounded Context)"]
+        CMP_BC["Components\n(Bounded Context)"]
+
+        STY_BC -- "Conformist" --> REN_BC
+        LAY_BC -- "Conformist" --> REN_BC
+        CMP_BC -- "Conformist" --> STY_BC
+        CMP_BC -- "Conformist" --> LAY_BC
+        CMP_BC -- "Customer/Supplier" --> TEA_BC
+    end
+```
+
+---
+
+## Key Modules
+
+### phoenix/core
+
+Foundation primitives. Stdlib only (zero external dependencies for the core module).
+
+- Unicode/Emoji width calculation (UAX #11 compliant)
+- Grapheme cluster support
+- Color types and conversion
+- Terminal capability detection
+
+### phoenix/terminal
+
+ANSI terminal operations with platform abstraction.
+
+- Raw mode / cooked mode
+- Alternate screen buffer
+- Cursor visibility and positioning
+- Platform-specific backends (Windows Console, Unix termios)
+
+### phoenix/tea
+
+Elm Architecture (Model-View-Update) event loop.
+
+- Generic `Model[T]` interface with compile-time type safety
+- Command system (Quit, Batch, Sequence, custom)
+- Input reader with pipe-based cancellation
+- **InlineRenderer** — per-line diffing for non-alt-screen rendering
+- TTY control — run external processes (ExecProcess), suspend/resume
+- Platform support: Linux, macOS, Windows
+
+### phoenix/style
+
+CSS-like styling system.
+
+- Fluent builder API (`NewStyle().Bold().Foreground("#FF0000")`)
+- 8-stage rendering pipeline
+- Theme system with presets and runtime switching
+- Border, padding, margin support
+
+### phoenix/layout
+
+Flexbox and box model layout.
+
+- Box model (padding, margin, border, content sizing)
+- Flexbox (row/column direction, gap, flex grow/shrink)
+- Responsive sizing (percentage, fixed, min/max)
+
+### phoenix/render
+
+High-performance differential renderer.
+
+- Virtual buffer with dirty-region tracking
+- Differential rendering (only repaint changed cells)
+- Zero allocations on hot paths
+
+### phoenix/components
+
+Pre-built UI components, all following DDD:
+
+- **TextArea** / **TextInput** — with public cursor API for syntax highlighting
+- **List** — single/multi selection, filtering
+- **Viewport** — scrolling, follow mode, large content support
+- **Table** — sortable columns, custom cell renderers
+- **Modal** — focus trap, buttons, dimming
+- **Progress** — bar + 15 spinner styles
+- **Select** / **MultiSelect** / **Confirm** / **Form** — form components with validation
+
+### phoenix/mouse
+
+Mouse event handling.
+
+- All buttons (Left, Right, Middle, Wheel)
+- Click detection (single/double/triple)
+- Drag & drop state tracking
+- Multi-protocol support (SGR, X10, URxvt)
+
+### phoenix/clipboard
+
+Cross-platform clipboard access.
+
+- Native APIs (Windows user32.dll, macOS pbcopy/pbpaste, Linux xclip/xsel)
+- OSC 52 for SSH sessions (auto-detect)
+- DDD architecture with provider abstraction
+
+---
+
+## Rendering Architecture
+
+### Alt-Screen Mode
+
+Full terminal takeover. Uses phoenix/render's virtual buffer for differential rendering.
+
+### Inline Mode
+
+Non-alt-screen rendering via `InlineRenderer` in phoenix/tea:
+
+```
+Frame N:          Frame N+1:
+┌──────────┐      ┌──────────┐
+│ Line 1   │  →   │ Line 1   │  (unchanged — skipped)
+│ Line 2   │  →   │ Line 2*  │  (changed — rewritten + erase-to-EOL)
+│ Line 3   │  →   │          │  (removed — erase-screen-below)
+└──────────┘      └──────────┘
+
+Sequence: cursor-up(N-1) → \r → [per-line diff] → erase-below → \r
+```
+
+Features:
+- Per-line diffing (skip unchanged lines)
+- ANSI-preserving width truncation (color codes don't count)
+- Height clipping (keeps output within terminal bounds)
+- Thread-safe (mutex-protected)
+
+---
+
+## Testing Strategy
+
+| Layer | Coverage Target | Testing Approach |
+|-------|----------------|------------------|
+| Domain | Highest | Unit tests, property-based, fuzzing |
+| Application | High | Unit tests with mocked infrastructure |
+| Infrastructure | Moderate | Integration tests, platform-specific |
+| API | High | Example-based tests, ergonomics validation |
+
+### Test Utilities
+
+`phoenix/testing` provides mock terminal and test helpers:
+
+```go
+import phoenixtesting "github.com/phoenix-tui/phoenix/testing"
+
+mockTerm := phoenixtesting.NewMockTerminal()
+p := program.New(myModel, program.WithTerminal[MyModel](mockTerm))
+
+// Verify terminal operations
+assert.True(t, mockTerm.IsInRawMode())
+assert.Equal(t, 1, mockTerm.CallCount("HideCursor"))
+```
+
+---
+
+## Design Decisions
+
+Key architectural decisions are documented in [docs/dev/decisions/](dev/decisions/).
+
+Notable decisions:
+- **DDD over MVC** — Phoenix is a foundational framework used by multiple projects; rich domain models provide better maintainability and testability
+- **Multi-module monorepo** — Each module has its own `go.mod` for independent versioning; users install only what they need
+- **No Charm dependencies** — Built from scratch to fix fundamental issues (Unicode, performance, architecture)
+- **Generics for type safety** — Go 1.25+ generics eliminate `interface{}` casts in the Elm Architecture
+- **Pipe-based stdin cancellation** — Platform-agnostic approach that works on Windows Console, MSYS2/mintty, and Unix
+
+---
+
+## Resources
+
+- **[API Design](dev/API_DESIGN.md)** — API principles and comparison with Charm
+- **[Migration Guide](user/MIGRATION_GUIDE.md)** — Migrate from Bubbletea/Lipgloss/Bubbles
+- **[GoDoc](https://pkg.go.dev/github.com/phoenix-tui/phoenix)** — Full API reference
+
+---
+
+*Phoenix TUI Framework — DDD + Hexagonal Architecture + Modern Go*

--- a/docs/user/tutorials/README.md
+++ b/docs/user/tutorials/README.md
@@ -339,15 +339,14 @@ We want to make these tutorials better!
 
 ## Tutorial Versions
 
-These tutorials are for **Phoenix TUI v0.1.0**.
+These tutorials track the latest stable Phoenix TUI release.
 
 **API Stability:**
-- v0.1.x: Minor breaking changes possible
-- v1.0.0: API stable (semantic versioning)
+- Pre-1.0: Minor breaking changes possible
+- 1.0+: API stable (semantic versioning)
 
 **Updating Tutorials:**
 - We update tutorials with each release
-- Check tutorial footer for "Last updated" date
 - If API changed, tutorials will reflect it
 
 ---
@@ -401,7 +400,5 @@ Tutorials are part of Phoenix TUI Framework documentation.
 ---
 
 *Phoenix TUI Framework - Tutorial Series*
-*Version: 1.0.0 (for Phoenix v0.1.0)*
-*Last updated: 2025-01-04*
 
-Happy coding! 🚀
+Happy coding!

--- a/examples/cobra-cli/README.md
+++ b/examples/cobra-cli/README.md
@@ -121,7 +121,7 @@ This example could be built with Charm (Huh + Lipgloss), but Phoenix offers:
 | **Performance** | ~60 FPS | 29,000 FPS |
 | **Modularity** | Monolithic | DDD layers |
 | **Customization** | Limited | Full control |
-| **Test Coverage** | Unknown | 91.8% |
+| **Test Coverage** | Unknown | High (90%+ target) |
 
 ### Unicode Bug Example
 
@@ -153,12 +153,12 @@ prompt := "Name 👋: "  // Perfect width calculation ✓
 ### Add More Components
 
 ```go
-// Select dropdown (coming in v0.2.0)
+// Select dropdown (see phoenix/components)
 selectInput := components.NewSelect(
     components.WithOptions([]string{"Option 1", "Option 2"}),
 )
 
-// Confirm dialog (coming in v0.2.0)
+// Confirm dialog (see phoenix/components)
 confirm := components.NewConfirm(
     components.WithMessage("Are you sure?"),
 )

--- a/examples/context-menu/README.md
+++ b/examples/context-menu/README.md
@@ -187,6 +187,6 @@ After understanding this example:
 
 ---
 
-**Part of Phoenix TUI Framework Week 15 (Advanced Mouse Features)**
+**Part of Phoenix TUI Framework (Advanced Mouse Features)**
 **Author**: Phoenix TUI Contributors
 **License**: MIT

--- a/examples/drag-scroll/README.md
+++ b/examples/drag-scroll/README.md
@@ -115,7 +115,7 @@ The drag scroll implementation has **14 comprehensive tests** covering:
 - Immutability
 - Disabled state
 
-**Test coverage**: 98.6% (exceeds 95% target)
+**Test coverage**: Extensive (exceeds project targets)
 
 Run tests:
 ```bash

--- a/examples/hover-highlight/README.md
+++ b/examples/hover-highlight/README.md
@@ -144,7 +144,7 @@ This example shows **low-level** hover detection suitable for custom components.
 For higher-level UI components (TextInput, Button, etc.), use **phoenix/components** which have built-in hover support:
 
 ```go
-// High-level component with hover (coming in phoenix/components v0.2.0)
+// High-level component with hover (see phoenix/components)
 btn := components.NewButton().
     Text("Click Me").
     OnHover(func(hovered bool) { /* ... */ }).
@@ -181,4 +181,3 @@ See [phoenix/mouse documentation](../../mouse/README.md) for full API details:
 
 **Phoenix TUI Framework** - Modern TUI library for Go
 **GitHub**: https://github.com/phoenix-tui/phoenix
-**Version**: v0.1.0-beta.5 (Week 15 - Mouse & Clipboard)

--- a/examples/wheel-scroll/README.md
+++ b/examples/wheel-scroll/README.md
@@ -82,7 +82,7 @@ Wheel scrolling is highly optimized:
 
 ## Testing
 
-The feature has comprehensive test coverage (98.7%):
+The feature has comprehensive test coverage:
 - Custom scroll values (1, 5, 10+ lines)
 - Boundary conditions (top/bottom)
 - Small content (no scrolling needed)
@@ -92,13 +92,11 @@ The feature has comprehensive test coverage (98.7%):
 
 See `components/viewport/viewport_test.go` for full test suite.
 
-## Week 15 Day 5-6 Deliverable
+## Features Demonstrated
 
-This example demonstrates:
-1. ✅ Configurable wheel scroll speed (SetWheelScrollLines API)
-2. ✅ Dynamic speed adjustment (change on the fly)
-3. ✅ Real-time feedback (statistics display)
-4. ✅ Edge case handling (bounds, small content)
-5. ✅ Production-ready implementation (98.7% test coverage)
+1. Configurable wheel scroll speed (SetWheelScrollLines API)
+2. Dynamic speed adjustment (change on the fly)
+3. Real-time feedback (statistics display)
+4. Edge case handling (bounds, small content)
 
-Part of Phoenix TUI Framework - Week 15-16: Advanced Features
+Part of Phoenix TUI Framework

--- a/layout/README.md
+++ b/layout/README.md
@@ -2,19 +2,17 @@
 
 Phoenix Layout implements a CSS-like box model and Flexbox layout for terminal user interfaces with support for padding, margins, borders, alignment, and flexible layouts.
 
-**Status**: ✅ Week 9-10 Complete - Box Model + Flexbox Ready
 **Module**: `github.com/phoenix-tui/phoenix/layout`
-**Coverage**: 98.3% (API), 99.2% (domain/model), 95.6% (domain/service)
 
 ## Features
 
-- ✅ **CSS Box Model** - Content, padding, border, margin layers
-- ✅ **Flexbox Layout** - Row/column layouts with flexible sizing (NEW!)
-- ✅ **Unicode-Aware** - Correct width calculation for CJK and emoji
-- ✅ **Fluent API** - Chainable method calls for easy styling
-- ✅ **Type-Safe** - Compile-time guarantees
-- ✅ **DDD Architecture** - Clean, testable, maintainable
-- ✅ **98%+ Coverage** - Comprehensive test suite
+- **CSS Box Model** - Content, padding, border, margin layers
+- **Flexbox Layout** - Row/column layouts with flexible sizing
+- **Unicode-Aware** - Correct width calculation for CJK and emoji
+- **Fluent API** - Chainable method calls for easy styling
+- **Type-Safe** - Compile-time guarantees
+- **DDD Architecture** - Clean, testable, maintainable
+- **Extensive test coverage** - Comprehensive test suite
 
 ## Quick Start
 
@@ -38,11 +36,11 @@ func main() {
 
 Output:
 ```
-┌─────────────┐
-│             │
-│ Hello World │
-│             │
-└─────────────┘
++---------------+
+|               |
+| Hello World   |
+|               |
++---------------+
 ```
 
 ## API Reference
@@ -101,7 +99,7 @@ pos := box.Layout(80, 24)       // Position in parent
 fmt.Printf("At (%d, %d)\n", pos.X(), pos.Y())
 ```
 
-## Flexbox Layout (NEW!)
+## Flexbox Layout
 
 ### Creating Flexbox Containers
 
@@ -159,14 +157,14 @@ flex.AlignCenter()   // Center items
 
 Visual (Row):
 ```
-AlignStretch:  ┌───┐ ┌───┐ ┌───┐
-               │ 1 │ │ 2 │ │ 3 │  ← All same height
-               └───┘ └───┘ └───┘
+AlignStretch:  +---+ +---+ +---+
+               | 1 | | 2 | | 3 |  <- All same height
+               +---+ +---+ +---+
 
-AlignStart:    ┌───┐ ┌───┐ ┌───┐
-               │ 1 │ │ 2 │ │ 3 │  ← Aligned to top
-               │   │ └───┘ │   │
-               └───┘       └───┘
+AlignStart:    +---+ +---+ +---+
+               | 1 | | 2 | | 3 |  <- Aligned to top
+               |   | +---+ |   |
+               +---+       +---+
 ```
 
 ### Gap Spacing
@@ -240,18 +238,18 @@ go run ./examples/shell_layouts/complex     # Nested and complex layouts
 ## Box Model
 
 ```
-┌─────────────────────────┐
-│       Margin            │  ← Outside spacing
-│  ┌──────────────────┐   │
-│  │     Border       │   │  ← Visual boundary
-│  │  ┌───────────┐   │   │
-│  │  │  Padding  │   │   │  ← Inside spacing
-│  │  │ ┌───────┐ │   │   │
-│  │  │ │Content│ │   │   │  ← Text content
-│  │  │ └───────┘ │   │   │
-│  │  └───────────┘   │   │
-│  └──────────────────┘   │
-└─────────────────────────┘
++-------------------------+
+|       Margin            |  <- Outside spacing
+|  +------------------+   |
+|  |     Border       |   |  <- Visual boundary
+|  |  +-----------+   |   |
+|  |  |  Padding  |   |   |  <- Inside spacing
+|  |  | +-------+ |   |   |
+|  |  | |Content| |   |   |  <- Text content
+|  |  | +-------+ |   |   |
+|  |  +-----------+   |   |
+|  +------------------+   |
++-------------------------+
 ```
 
 ## Architecture
@@ -262,28 +260,9 @@ layout/
 │   ├── model/      # Box, Node entities
 │   ├── value/      # Size, Position, Spacing
 │   └── service/    # Measure, Layout, Render services
-├── api/            # Public fluent API (100% coverage)
+├── api/            # Public fluent API
 └── examples/       # Usage examples
 ```
-
-## Status
-
-### Week 9 (Complete)
-- ✅ Day 1-2: Value Objects + Domain Models (Size, Position, Spacing, Alignment, Box, Node)
-- ✅ Day 3: Layout Engine Services (Measure, Layout, Render)
-- ✅ Day 4: Public API + Examples + Documentation
-
-### Week 10 (Complete)
-- ✅ Day 5: Flexbox Domain Model (FlexContainer, Direction, JustifyContent, AlignItems)
-- ✅ Day 6: Flexbox Layout Engine (Row/column distribution, gap support)
-- ✅ Day 7: Flexbox Public API + Shell Layout Examples
-
-## Roadmap
-
-### v0.2.0 (Future)
-- Grid layout
-- Absolute positioning
-- Z-index stacking
 
 ## Testing
 
@@ -292,13 +271,6 @@ go test ./...              # All tests
 go test ./... -cover       # With coverage
 go test ./api/... -v       # API tests verbose
 ```
-
-**Current Coverage**:
-- API: 98.3%
-- Domain/Model: 99.2%
-- Domain/Service: 95.6%
-- Domain/Value: 98.5%
-- **Overall: 97.9%** (exceeds 95% target!)
 
 ## License
 

--- a/mouse/README.md
+++ b/mouse/README.md
@@ -4,23 +4,20 @@
 
 Part of the Phoenix TUI Framework.
 
-**Status**: ✅ Production Ready (Week 16)
 **Module**: `github.com/phoenix-tui/phoenix/mouse`
-**Version**: v0.1.0-alpha
-**Coverage**: ~60% (working toward 90%+)
 
 ---
 
 ## Features
 
-- ✅ **All Mouse Buttons**: Left, Right, Middle, Scroll Wheel
-- ✅ **Click Detection**: Single, Double, Triple clicks (automatic)
-- ✅ **Drag & Drop**: State tracking with threshold detection
-- ✅ **Scroll Wheel**: Up/Down with configurable delta
-- ✅ **Modifier Keys**: Shift, Ctrl, Alt detection
-- ✅ **Multi-Protocol**: SGR (modern), X10 (legacy), URxvt (alternative)
-- ✅ **DDD Architecture**: Rich domain models with behavior
-- ✅ **Zero Dependencies**: Built from scratch (stdlib only)
+- **All Mouse Buttons**: Left, Right, Middle, Scroll Wheel
+- **Click Detection**: Single, Double, Triple clicks (automatic)
+- **Drag & Drop**: State tracking with threshold detection
+- **Scroll Wheel**: Up/Down with configurable delta
+- **Modifier Keys**: Shift, Ctrl, Alt detection
+- **Multi-Protocol**: SGR (modern), X10 (legacy), URxvt (alternative)
+- **DDD Architecture**: Rich domain models with behavior
+- **Zero Dependencies**: Built from scratch (stdlib only)
 
 ---
 
@@ -70,8 +67,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 ```go
 mouse.ButtonNone       // No button (motion only)
-mouse.ButtonLeft       // Left mouse button ⭐
-mouse.ButtonRight      // Right mouse button ⭐
+mouse.ButtonLeft       // Left mouse button
+mouse.ButtonRight      // Right mouse button
 mouse.ButtonMiddle     // Middle button (scroll wheel press)
 mouse.ButtonWheelUp    // Scroll wheel up
 mouse.ButtonWheelDown  // Scroll wheel down
@@ -141,7 +138,7 @@ func (i *Input) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 ```
 
-### 2. Context Menu (Right Click) ⭐
+### 2. Context Menu (Right Click)
 
 ```go
 type Model struct {
@@ -261,7 +258,7 @@ case tea.MouseMsg:
 ```
 
 **Detection Rules**:
-- **Double click**: Two clicks within 500ms at same position (±1 cell tolerance)
+- **Double click**: Two clicks within 500ms at same position (+-1 cell tolerance)
 - **Triple click**: Three clicks within 500ms at same position
 - Automatic timeout after 500ms
 
@@ -301,7 +298,7 @@ case tea.MouseMsg:
 
 Phoenix supports multiple mouse protocols with automatic fallback:
 
-### SGR (1006) - Modern ⭐ PREFERRED
+### SGR (1006) - Modern (Preferred)
 
 ```
 \x1b[<0;10;5M   # Left press at (10, 5)
@@ -370,7 +367,7 @@ input := textinput.New().
     WithPlaceholder("Click to position cursor...").
     WithMouseSupport(true)  // Enable mouse clicks
 
-// User clicks at X coordinate → cursor moves to that position
+// User clicks at X coordinate -> cursor moves to that position
 ```
 
 ### Viewport - Scrolling
@@ -382,7 +379,7 @@ viewport := viewport.New(80, 20).
     WithContent(longText).
     WithMouseScroll(true)  // Enable scroll wheel
 
-// User scrolls wheel → viewport scrolls up/down
+// User scrolls wheel -> viewport scrolls up/down
 ```
 
 ### List - Item Selection
@@ -393,8 +390,8 @@ Phoenix List supports click selection:
 list := list.New(items).
     WithMouseSelect(true)  // Enable click selection
 
-// User clicks item → item selected
-// User right-clicks item → context menu?
+// User clicks item -> item selected
+// User right-clicks item -> context menu?
 ```
 
 ---
@@ -463,16 +460,16 @@ mouse/
 
 | Platform | Protocol | Support |
 |----------|----------|---------|
-| **iTerm2** | SGR (1006) | ✅ Full |
-| **Windows Terminal** | SGR (1006) | ✅ Full |
-| **Alacritty** | SGR (1006) | ✅ Full |
-| **Kitty** | SGR (1006) | ✅ Full |
-| **xterm** | SGR (1006) | ✅ Full |
-| **tmux** | SGR (1006) | ✅ Full |
-| **Terminal.app** (macOS) | SGR (1006) | ✅ Full |
-| **GNOME Terminal** | SGR (1006) | ✅ Full |
-| **Old xterm** | X10 (1000) | ⚠️ Limited |
-| **PuTTY** | X10 (1000) | ⚠️ Limited |
+| **iTerm2** | SGR (1006) | Full |
+| **Windows Terminal** | SGR (1006) | Full |
+| **Alacritty** | SGR (1006) | Full |
+| **Kitty** | SGR (1006) | Full |
+| **xterm** | SGR (1006) | Full |
+| **tmux** | SGR (1006) | Full |
+| **Terminal.app** (macOS) | SGR (1006) | Full |
+| **GNOME Terminal** | SGR (1006) | Full |
+| **Old xterm** | X10 (1000) | Limited |
+| **PuTTY** | X10 (1000) | Limited |
 
 ---
 
@@ -518,45 +515,26 @@ See `examples/` directory:
 |---------|---------|-----------|
 | **Click Detection** | Built-in | Manual |
 | **Drag Tracking** | Built-in | Manual |
-| **Right Click** | ✅ Full support | ✅ Supported |
-| **Middle Click** | ✅ Full support | ✅ Supported |
+| **Right Click** | Full support | Supported |
+| **Middle Click** | Full support | Supported |
 | **Protocol Abstraction** | DDD | Raw events |
 | **Domain Model** | Rich | Anemic |
-| **Test Coverage** | 60%+ (→90%) | Unknown |
-
----
-
-## Roadmap
-
-### v0.1.0 (Current)
-- ✅ All button support (Left, Right, Middle, Wheel)
-- ✅ Click detection (single, double, triple)
-- ✅ Drag & drop tracking
-- ✅ Scroll wheel
-- ✅ SGR protocol
-- ⏳ 90% test coverage (currently ~60%)
-
-### v0.2.0 (Future)
-- Hover events (motion tracking)
-- Touch events (mobile terminals)
-- Gesture recognition
-- Advanced drag & drop (file types, MIME)
 
 ---
 
 ## FAQ
 
 **Q: Does right click work?**
-A: ✅ Yes! Full support for left, right, and middle buttons.
+A: Yes! Full support for left, right, and middle buttons.
 
 **Q: How do I show a context menu on right click?**
 A: Check `msg.Button == mouse.ButtonRight` and render your context menu component.
 
 **Q: Can I detect double-click?**
-A: ✅ Yes! Phoenix automatically detects double and triple clicks.
+A: Yes! Phoenix automatically detects double and triple clicks.
 
 **Q: Does scroll wheel work in SSH?**
-A: ✅ Yes, if your terminal supports SGR protocol (most modern terminals do).
+A: Yes, if your terminal supports SGR protocol (most modern terminals do).
 
 **Q: How do I enable mouse support?**
 A: Call `mouse.Enable()` at program start, or use `tea.WithMouseCellMotion()` in tea.Program options.
@@ -578,11 +556,3 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines.
 ## Credits
 
 Part of the **Phoenix TUI Framework** - Next-generation terminal UI for Go.
-
-**Week 16 Implementation** - Mouse & Clipboard support complete.
-
----
-
-*Documentation Version: 1.0*
-*Last Updated: 2025-10-17*
-*Status: Production Ready*

--- a/render/README.md
+++ b/render/README.md
@@ -2,14 +2,11 @@
 
 High-performance differential rendering engine for Phoenix TUI Framework.
 
-**Status**: Week 13-14 Complete ✅  
-**Coverage**: 90%+ target  
-**Performance**: 60 FPS (< 16.67ms per frame)  
-**Version**: v0.1.0-alpha.0
+**Module**: `github.com/phoenix-tui/phoenix/render`
 
 ## Features
 
-- **Differential Rendering**: Only renders changed cells (10x faster than full redraws)
+- **Differential Rendering**: Only renders changed cells (significantly faster than full redraws)
 - **ANSI Optimization**: Batches escape sequences for minimal output
 - **Zero-Allocation Hot Paths**: Buffer pooling for garbage-free rendering
 - **Unicode Perfect**: Correct grapheme cluster handling (emoji, CJK, etc.)
@@ -57,8 +54,7 @@ See full API documentation in this file.
 
 ## Performance
 
-Target: 60 FPS (< 16.67ms per frame)  
-Achieved: ✅ 10x faster than Charm ecosystem
+Target: 60 FPS (< 16.67ms per frame)
 
 Run benchmarks:
 ```bash

--- a/style/README.md
+++ b/style/README.md
@@ -2,9 +2,7 @@
 
 Universal styling library for terminal UI applications. Part of the Phoenix TUI Framework.
 
-**Status**: ✅ Complete (Week 5 Day 1-6)
 **Module**: `github.com/phoenix-tui/phoenix/style`
-**Coverage**: 90%+ overall (96.6% domain, 100% API)
 
 ## Features
 
@@ -12,12 +10,13 @@ Universal styling library for terminal UI applications. Part of the Phoenix TUI 
 - **Borders**: 6 pre-defined styles (Rounded, Thick, Double, Normal, ASCII, Hidden)
 - **Spacing**: CSS-like padding and margin (top, right, bottom, left)
 - **Sizing**: Width/height constraints with min/max bounds
-- **Alignment**: 9 alignment combinations (horizontal × vertical)
+- **Alignment**: 9 alignment combinations (horizontal x vertical)
 - **Text Decorations**: Bold, italic, underline, strikethrough
 - **Unicode Correct**: Perfect emoji, CJK, combining character support
 - **Fluent API**: Method chaining for intuitive style building
 - **Immutable**: Thread-safe value objects
 - **DDD Architecture**: Rich domain models, pure business logic
+- **Extensive test coverage** across all layers
 
 ## Quick Start
 
@@ -74,7 +73,7 @@ func main() {
         Bold(true).
         Width(50)
 
-    message := "🔔 Notification: Your task is complete!"
+    message := "Notification: Your task is complete!"
 
     // Render and display
     fmt.Println(style.Render(notificationStyle, message))
@@ -83,9 +82,9 @@ func main() {
 
 Output:
 ```
-╭────────────────────────────────────────────────╮
-│  🔔 Notification: Your task is complete!      │
-╰────────────────────────────────────────────────╯
++------------------------------------------------+
+|  Notification: Your task is complete!          |
++------------------------------------------------+
 ```
 
 ## API Documentation
@@ -114,22 +113,22 @@ style.Cyan, style.Magenta, style.White, style.Black, style.Gray
 
 ```go
 // Pre-defined borders
-style.NormalBorder    // ┌─┐ │ └─┘
-style.RoundedBorder   // ╭─╮ │ ╰─╯
-style.ThickBorder     // ┏━┓ ┃ ┗━┛
-style.DoubleBorder    // ╔═╗ ║ ╚═╝
+style.NormalBorder    // +--+ | +--+
+style.RoundedBorder   // +--+ | +--+
+style.ThickBorder     // +==+ | +==+
+style.DoubleBorder    // +==+ | +==+
 style.ASCIIBorder     // +-+ | +-+
 
 // Custom border
 border := style.NewBorder(
-    "─",  // top
-    "─",  // bottom
-    "│",  // left
-    "│",  // right
-    "┌",  // top-left
-    "┐",  // top-right
-    "└",  // bottom-left
-    "┘",  // bottom-right
+    "-",  // top
+    "-",  // bottom
+    "|",  // left
+    "|",  // right
+    "+",  // top-left
+    "+",  // top-right
+    "+",  // bottom-left
+    "+",  // bottom-right
 )
 
 // Apply border
@@ -232,7 +231,7 @@ style.StrikethroughStyle
 // Adapt colors to terminal capabilities
 s := style.New().
     Foreground(style.RGB(255, 0, 0)).
-    TerminalCapability(style.ANSI256)  // TrueColor → ANSI256 → ANSI16
+    TerminalCapability(style.ANSI256)  // TrueColor -> ANSI256 -> ANSI16
 
 // Constants
 style.TrueColor   // 24-bit RGB (16.7 million colors)
@@ -260,15 +259,15 @@ Phoenix style library follows Domain-Driven Design:
 
 ```
 style/
-├── domain/           # Pure business logic (95%+ coverage)
+├── domain/           # Pure business logic
 │   ├── model/       # Style domain model
 │   ├── value/       # Value objects (Color, Border, Padding, etc.)
 │   └── service/     # Domain services (ColorAdapter, TextAligner, etc.)
-├── application/      # Use cases (90%+ coverage)
+├── application/      # Use cases
 │   └── command/     # RenderCommand (styling pipeline)
-├── infrastructure/   # Technical details (100% coverage)
+├── infrastructure/   # Technical details
 │   └── ansi/        # ANSI code generation
-└── api/             # Public interface (100% coverage)
+└── api/             # Public interface
     └── style.go     # Fluent API
 ```
 
@@ -278,12 +277,11 @@ Compared to Lipgloss (Charm ecosystem):
 
 | Feature | Phoenix | Lipgloss |
 |---------|---------|----------|
-| **Unicode Support** | ✅ Perfect (emoji, CJK, combining chars) | ❌ [Broken since Aug 2024](https://github.com/charmbracelet/lipgloss/issues/562) |
-| **Performance** | ✅ 10x faster (< 50ms for 1K renders) | ⚠️ 450ms for 1K renders |
-| **Architecture** | ✅ DDD + Rich Models | ⚠️ Monolithic |
-| **Test Coverage** | ✅ 90%+ (96.6% domain) | ⚠️ ~60% |
-| **Immutability** | ✅ Fully immutable | ⚠️ Partial |
-| **API Design** | ✅ Fluent + type-safe | ✅ Good |
+| **Unicode Support** | Perfect (emoji, CJK, combining chars) | [Broken since Aug 2024](https://github.com/charmbracelet/lipgloss/issues/562) |
+| **Performance** | Significantly faster | Slower with large content |
+| **Architecture** | DDD + Rich Models | Monolithic |
+| **Immutability** | Fully immutable | Partial |
+| **API Design** | Fluent + type-safe | Good |
 
 ## Testing
 
@@ -301,34 +299,11 @@ go test ./domain/model/...
 go test -run Integration ./...
 ```
 
-**Test Coverage**:
-- Domain model: 92.3%
-- Domain services: 95.7%
-- Domain values: 97.5%
-- Infrastructure: 100%
-- API: 100%
-- Application: 76.9%
-- **Overall**: 90%+
-
 ## Documentation
 
 - **[Value Objects](internal/domain/value/README.md)** - Color, Border, Padding, Margin, Size, Alignment
 - **[Domain Model](internal/domain/model/)** - Style domain model documentation
 - **Examples** - [examples/](examples/) directory
-
-## Roadmap
-
-**Week 5 (Current)**: ✅ Complete
-- ✅ Day 1-2: Color & Border System
-- ✅ Day 3-4: Spacing & Sizing
-- ✅ Day 5-6: Style Model + Fluent API + Render
-
-**Week 6-7 (Next)**: Terminal & Event Loop
-- phoenix/tea - Elm Architecture implementation
-- phoenix/terminal - Low-level terminal operations
-
-**Week 9-10**: Layout System
-- phoenix/layout - Flexbox & Grid layout
 
 ## Contributing
 
@@ -341,5 +316,4 @@ MIT (planned)
 ---
 
 **Part of Phoenix TUI Framework**
-**Version**: 0.1.0-dev (Week 5 complete)
 **Go Version**: 1.25+

--- a/style/internal/domain/value/README.md
+++ b/style/internal/domain/value/README.md
@@ -397,17 +397,7 @@ fmt.Println(alignment.String())  // "Alignment(Center, Middle)"
 
 ## Testing
 
-All value objects have comprehensive test coverage:
-
-- **Color**: 92.2% coverage (86 tests)
-- **TerminalCapability**: 100% coverage (6 tests)
-- **Border**: 100% coverage (8 tests)
-- **Padding**: 97.8% coverage (12 tests)
-- **Margin**: 97.8% coverage (13 tests)
-- **Size**: 96.6% coverage (16 tests)
-- **Alignment**: 98.6% coverage (11 tests)
-
-**Overall**: 97.5% coverage
+All value objects have comprehensive test coverage across every type (Color, TerminalCapability, Border, Padding, Margin, Size, Alignment).
 
 Run tests:
 
@@ -424,5 +414,4 @@ go test ./domain/value/... -cover
 ---
 
 **Package**: `github.com/phoenix-tui/phoenix/style/domain/value`
-**Version**: 0.1.0 (Week 5 Day 1-4)
 **Architecture**: DDD Value Objects (immutable, pure domain logic)

--- a/tea/examples/README.md
+++ b/tea/examples/README.md
@@ -301,4 +301,4 @@ case service.TickMsg:
 
 ---
 
-*Examples created for Week 6 Day 7 - phoenix/tea v1.0*
+*phoenix/tea examples*

--- a/tea/internal/infrastructure/renderer/inline.go
+++ b/tea/internal/infrastructure/renderer/inline.go
@@ -1,0 +1,420 @@
+// Package renderer provides inline (non-alt-screen) rendering for the tea module.
+// InlineRenderer tracks the number of lines rendered in the previous frame and
+// uses ANSI cursor-up sequences to overwrite the previous frame on each update,
+// preventing the stacked-output bug where each render appends below the last.
+package renderer
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"unicode"
+)
+
+// ANSI escape sequences used for inline rendering.
+const (
+	// eraseLineRight erases from the cursor to the end of the current line.
+	// Equivalent to \x1b[0K. Used after writing each line to clear leftover chars.
+	eraseLineRight = "\x1b[K"
+
+	// eraseScreenBelow erases from the cursor to the end of the screen.
+	// Used when the new frame has fewer lines than the previous frame.
+	eraseScreenBelow = "\x1b[J"
+
+	// carriageReturn moves the cursor to column 0 of the current line.
+	carriageReturn = "\r"
+)
+
+// cursorUp returns the ANSI sequence to move the cursor up n lines.
+// Returns empty string if n <= 0.
+func cursorUp(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("\x1b[%dA", n)
+}
+
+// InlineRenderer handles inline (non-alt-screen) rendering.
+//
+// It tracks the number of lines from the previous render frame and uses
+// ANSI cursor-up sequences to return to the top of the rendered region
+// before overwriting. Per-line diffing skips unchanged lines to minimize I/O.
+//
+// All public methods are safe for concurrent use.
+type InlineRenderer struct {
+	out           io.Writer
+	width         int      // terminal width; 0 means no truncation
+	height        int      // terminal height; 0 means no clipping
+	lastView      string   // raw string of the previous render (for identical-frame check)
+	lastLines     []string // previous render split by "\n" (for per-line diffing)
+	linesRendered int      // number of lines written in the previous render
+	mu            sync.Mutex
+}
+
+// NewInlineRenderer creates a new InlineRenderer writing to out.
+//
+// width and height are the current terminal dimensions. Pass 0 to disable
+// truncation (width) and clipping (height). Call Resize when the terminal
+// dimensions change.
+func NewInlineRenderer(out io.Writer, width, height int) *InlineRenderer {
+	return &InlineRenderer{
+		out:    out,
+		width:  width,
+		height: height,
+	}
+}
+
+// Render writes view to the output, overwriting the previous render frame.
+//
+// On the first call it writes the content with ANSI line-erase sequences.
+// On subsequent calls it moves the cursor back to the top of the rendered
+// region and rewrites only the lines that changed since the last call.
+//
+// Returns nil on success. Write errors are returned to the caller but do not
+// corrupt internal state (a failed render can be retried).
+func (r *InlineRenderer) Render(view string) error { //nolint:gocognit,gocyclo,cyclop // render loop with per-line diffing has inherent branching
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// No-op if the view is identical to the previous render.
+	if view == r.lastView && r.linesRendered > 0 {
+		return nil
+	}
+
+	buf := &bytes.Buffer{}
+
+	// Move cursor back to the top of the previously rendered region.
+	// When linesRendered == 0 this is the first render; no cursor-up needed.
+	if r.linesRendered > 1 {
+		buf.WriteString(cursorUp(r.linesRendered - 1))
+	}
+	// Return to column 0 of the current line (handles both first render
+	// and subsequent renders where cursor sits at end of last line).
+	buf.WriteString(carriageReturn)
+
+	newLines := strings.Split(view, "\n")
+
+	// Clip to terminal height — cannot scroll into the scrollback buffer
+	// while the inline render region is active.
+	if r.height > 0 && len(newLines) > r.height {
+		newLines = newLines[len(newLines)-r.height:]
+	}
+
+	for i, line := range newLines {
+		// Truncate to terminal width to prevent line wrap, which would
+		// inflate the physical line count and corrupt cursor positioning.
+		if r.width > 0 {
+			line = truncateLine(line, r.width)
+		}
+
+		// Per-line diff: skip lines that are identical to the previous render.
+		// Compare using the original (pre-truncation) content because lastLines
+		// also stores originals. If width changed, Resize() clears the cache.
+		if i < len(r.lastLines) && r.lastLines[i] == newLines[i] {
+			if i < len(newLines)-1 {
+				buf.WriteString("\r\n")
+			}
+			continue
+		}
+
+		// Write the (possibly truncated) line content followed by erase-to-EOL.
+		// The erase sequence clears any leftover characters from a longer previous line.
+		buf.WriteString(line)
+		buf.WriteString(eraseLineRight)
+
+		if i < len(newLines)-1 {
+			buf.WriteString("\r\n")
+		}
+	}
+
+	// Erase any extra lines from the previous render that are no longer present.
+	if r.linesRendered > len(newLines) {
+		buf.WriteString(eraseScreenBelow)
+	}
+
+	// Leave cursor at column 0 of the last rendered line for consistent positioning.
+	buf.WriteString(carriageReturn)
+
+	_, err := r.out.Write(buf.Bytes())
+	if err != nil {
+		return err
+	}
+
+	// Update state only after a successful write.
+	r.linesRendered = len(newLines)
+	r.lastView = view
+	r.lastLines = newLines
+
+	return nil
+}
+
+// Repaint clears the per-line diff cache so the next Render call performs a
+// full repaint of all lines. Call this after Resume() to restore the TUI view
+// after an external process has written to the terminal.
+//
+// NOTE: linesRendered is intentionally NOT reset here. The cursor is still at
+// the end of the last rendered region; the next Render will move it back up
+// the correct number of lines.
+func (r *InlineRenderer) Repaint() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.lastView = ""
+	r.lastLines = nil
+}
+
+// Resize updates the terminal dimensions and forces a full repaint on the next
+// Render call. Call this when a WindowSizeMsg is received.
+func (r *InlineRenderer) Resize(width, height int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.width = width
+	r.height = height
+	r.lastView = ""
+	r.lastLines = nil
+}
+
+// SetOutput changes the destination writer. Useful for redirecting output
+// without recreating the renderer (e.g., after a terminal handoff).
+func (r *InlineRenderer) SetOutput(w io.Writer) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.out = w
+	r.lastView = ""
+	r.lastLines = nil
+	r.linesRendered = 0
+}
+
+// ─── Internal helpers ────────────────────────────────────────────────────────
+
+// stripANSI removes ANSI escape sequences from s and returns the plain text.
+// This is used to compute the visual display width of a line that may contain
+// color codes, bold, underline, etc.
+//
+// Supported sequence types:
+//   - CSI sequences: ESC [ <params> <final>  (e.g. \x1b[31m, \x1b[2A, \x1b[K)
+//   - OSC sequences: ESC ] ... BEL
+//   - Other two-byte sequences: ESC <single-char>
+func stripANSI(s string) string { //nolint:gocognit,gocyclo,cyclop // byte-level ANSI escape parser with CSI/OSC/two-byte branches
+	var b strings.Builder
+	b.Grow(len(s))
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		if c != '\x1b' {
+			b.WriteByte(c)
+			i++
+			continue
+		}
+		// ESC found. Peek at the next byte to determine sequence type.
+		i++ // consume ESC
+		if i >= len(s) {
+			break
+		}
+		next := s[i]
+		switch next {
+		case '[': // CSI: consume until final byte in range 0x40-0x7E
+			i++ // consume '['
+			for i < len(s) {
+				fc := s[i]
+				i++
+				if fc >= 0x40 && fc <= 0x7E {
+					break // final byte consumed
+				}
+			}
+		case ']': // OSC: consume until BEL (0x07) or ESC (start of ST)
+			i++ // consume ']'
+			for i < len(s) {
+				fc := s[i]
+				i++
+				if fc == 0x07 {
+					break
+				}
+				if fc == '\x1b' {
+					// ST = ESC \ — consume the '\'
+					if i < len(s) && s[i] == '\\' {
+						i++
+					}
+					break
+				}
+			}
+		default:
+			// Two-byte sequence: ESC <char> — skip the next char
+			i++
+		}
+	}
+	return b.String()
+}
+
+// runeDisplayWidth returns the display width of a single rune.
+// Wide characters (CJK, fullwidth) count as 2 columns; most others count as 1.
+// Control characters and combining marks count as 0.
+func runeDisplayWidth(r rune) int { //nolint:gocognit,gocyclo,cyclop,funlen // Unicode width lookup table across 18 codepoint ranges
+	// Control characters occupy 0 visible columns.
+	if r < 0x20 || (r >= 0x7F && r < 0xA0) {
+		return 0
+	}
+	// East Asian Wide and Fullwidth ranges that occupy 2 columns.
+	switch {
+	case r >= 0x1100 && r <= 0x115F: // Hangul Jamo
+		return 2
+	case r == 0x2329 || r == 0x232A: // Angle brackets
+		return 2
+	case r >= 0x2E80 && r <= 0x303E: // CJK Radicals, etc.
+		return 2
+	case r >= 0x3040 && r <= 0x33FF: // Japanese, Katakana, Bopomofo, etc.
+		return 2
+	case r >= 0x3400 && r <= 0x4DBF: // CJK Extension A
+		return 2
+	case r >= 0x4E00 && r <= 0xA4CF: // CJK Unified Ideographs
+		return 2
+	case r >= 0xA960 && r <= 0xA97F: // Hangul Jamo Extended-A
+		return 2
+	case r >= 0xAC00 && r <= 0xD7FF: // Hangul Syllables + Jamo Extended-B
+		return 2
+	case r >= 0xF900 && r <= 0xFAFF: // CJK Compatibility Ideographs
+		return 2
+	case r >= 0xFE10 && r <= 0xFE1F: // Vertical forms
+		return 2
+	case r >= 0xFE30 && r <= 0xFE6F: // CJK Compatibility Forms
+		return 2
+	case r >= 0xFF00 && r <= 0xFF60: // Fullwidth Forms
+		return 2
+	case r >= 0xFFE0 && r <= 0xFFE6: // Fullwidth Signs
+		return 2
+	case r >= 0x1B000 && r <= 0x1B0FF: // Kana Supplement
+		return 2
+	case r >= 0x1F004 && r <= 0x1F0CF: // Playing cards, Mahjong
+		return 2
+	case r >= 0x1F300 && r <= 0x1F9FF: // Miscellaneous Symbols + Emoji
+		return 2
+	case r >= 0x20000 && r <= 0x2FFFD: // CJK Extension B-F
+		return 2
+	case r >= 0x30000 && r <= 0x3FFFD: // CJK Extension G+
+		return 2
+	}
+	// Combining / zero-width characters.
+	if unicode.In(r, unicode.Mn, unicode.Me, unicode.Cf) {
+		return 0
+	}
+	return 1
+}
+
+// visualWidth returns the number of terminal columns that s occupies,
+// ignoring any ANSI escape sequences.
+func visualWidth(s string) int {
+	plain := stripANSI(s)
+	w := 0
+	for _, r := range plain {
+		w += runeDisplayWidth(r)
+	}
+	return w
+}
+
+// truncateLine truncates s so that its visual display width does not exceed
+// maxWidth columns. ANSI escape sequences are preserved in the output but
+// do not count toward the width budget. If the line fits within maxWidth
+// the original string is returned unchanged.
+func truncateLine(s string, maxWidth int) string { //nolint:gocognit,gocyclo,cyclop,funlen // ANSI-preserving truncation with CSI/OSC/two-byte parsing
+	if maxWidth <= 0 || visualWidth(s) <= maxWidth {
+		return s
+	}
+
+	var b strings.Builder
+	b.Grow(len(s))
+	width := 0
+	i := 0
+
+	for i < len(s) {
+		c := s[i]
+
+		// Pass ANSI escape sequences through without counting columns.
+		if c == '\x1b' { //nolint:nestif // ANSI escape parsing requires nested CSI/OSC/ST branches
+			b.WriteByte(c)
+			i++ // consume ESC
+			if i >= len(s) {
+				break
+			}
+			next := s[i]
+			b.WriteByte(next)
+			i++ // consume byte after ESC
+			switch next {
+			case '[': // CSI: consume until final byte in 0x40-0x7E
+				for i < len(s) {
+					fc := s[i]
+					b.WriteByte(fc)
+					i++
+					if fc >= 0x40 && fc <= 0x7E {
+						break
+					}
+				}
+			case ']': // OSC: consume until BEL or ESC
+				for i < len(s) {
+					fc := s[i]
+					b.WriteByte(fc)
+					i++
+					if fc == 0x07 {
+						break
+					}
+					if fc == '\x1b' {
+						if i < len(s) && s[i] == '\\' {
+							b.WriteByte(s[i])
+							i++
+						}
+						break
+					}
+				}
+				// default: two-byte sequence already consumed above
+			}
+			continue
+		}
+
+		// Decode rune and check remaining width budget.
+		r, size := decodeRune(s, i)
+		rw := runeDisplayWidth(r)
+		if width+rw > maxWidth {
+			break
+		}
+		b.WriteRune(r)
+		width += rw
+		i += size
+	}
+
+	return b.String()
+}
+
+// decodeRune decodes a UTF-8 rune from s starting at byte offset i.
+// Returns the rune and the number of bytes consumed.
+func decodeRune(s string, i int) (rune, int) {
+	b := s[i]
+	// Single-byte ASCII.
+	if b < 0x80 {
+		return rune(b), 1
+	}
+	// Multi-byte sequence: determine length from leading byte.
+	var size int
+	switch {
+	case b&0xE0 == 0xC0:
+		size = 2
+	case b&0xF0 == 0xE0:
+		size = 3
+	case b&0xF8 == 0xF0:
+		size = 4
+	default:
+		// Invalid lead byte — treat as replacement character.
+		return '\uFFFD', 1
+	}
+	if i+size > len(s) {
+		return '\uFFFD', 1
+	}
+	r := rune(b & (0xFF >> (size + 1)))
+	for j := 1; j < size; j++ {
+		cb := s[i+j]
+		if cb&0xC0 != 0x80 {
+			return '\uFFFD', 1
+		}
+		r = (r << 6) | rune(cb&0x3F)
+	}
+	return r, size
+}

--- a/tea/internal/infrastructure/renderer/inline_test.go
+++ b/tea/internal/infrastructure/renderer/inline_test.go
@@ -1,0 +1,1027 @@
+package renderer
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// ─── Constructor ─────────────────────────────────────────────────────────────
+
+func TestNewInlineRenderer(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewInlineRenderer(&buf, 80, 24)
+
+	if r == nil {
+		t.Fatal("NewInlineRenderer returned nil")
+	}
+	if r.out != &buf {
+		t.Error("out field not set correctly")
+	}
+	if r.width != 80 {
+		t.Errorf("width: want 80, got %d", r.width)
+	}
+	if r.height != 24 {
+		t.Errorf("height: want 24, got %d", r.height)
+	}
+	if r.linesRendered != 0 {
+		t.Errorf("linesRendered should be 0 initially, got %d", r.linesRendered)
+	}
+}
+
+// ─── First render ────────────────────────────────────────────────────────────
+
+// TestInlineRenderer_FirstRender verifies the first render writes content
+// correctly: no cursor-up, carriage return at start, erase-to-EOL per line,
+// carriage return at end.
+func TestInlineRenderer_FirstRender(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewInlineRenderer(&buf, 80, 24)
+
+	if err := r.Render("Hello\nWorld"); err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+
+	out := buf.String()
+
+	// Must contain the text.
+	if !strings.Contains(out, "Hello") {
+		t.Errorf("output missing 'Hello': %q", out)
+	}
+	if !strings.Contains(out, "World") {
+		t.Errorf("output missing 'World': %q", out)
+	}
+
+	// Must contain erase-to-EOL after each line.
+	if !strings.Contains(out, eraseLineRight) {
+		t.Errorf("output missing eraseLineRight (%q): %q", eraseLineRight, out)
+	}
+
+	// Must NOT contain cursor-up (first render, nothing to move up past).
+	if strings.Contains(out, "\x1b[") && strings.HasPrefix(out, "\x1b[") {
+		// Allow eraseLineRight and eraseScreenBelow but not cursor-up at start.
+		if strings.HasPrefix(out, "\x1b[1A") || strings.HasPrefix(out, "\x1b[2A") {
+			t.Errorf("first render should not start with cursor-up: %q", out)
+		}
+	}
+
+	// Must end with carriage return.
+	if !strings.HasSuffix(out, carriageReturn) {
+		t.Errorf("output should end with carriage return, got: %q", out)
+	}
+
+	// linesRendered must equal the number of lines.
+	if r.linesRendered != 2 {
+		t.Errorf("linesRendered: want 2, got %d", r.linesRendered)
+	}
+}
+
+// TestInlineRenderer_SingleLine verifies a single-line view does not produce
+// a cursor-up sequence (nothing to move past).
+func TestInlineRenderer_SingleLine(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewInlineRenderer(&buf, 80, 24)
+
+	if err := r.Render("Hello"); err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+
+	out := buf.String()
+
+	// No cursor-up sequence.
+	if strings.Contains(out, "\x1b[1A") {
+		t.Errorf("single line should not produce cursor-up: %q", out)
+	}
+
+	if r.linesRendered != 1 {
+		t.Errorf("linesRendered: want 1, got %d", r.linesRendered)
+	}
+}
+
+// ─── Second render (changed) ─────────────────────────────────────────────────
+
+// TestInlineRenderer_SecondRender_Changed verifies that on the second render:
+//   - cursor moves up (linesRendered - 1) lines
+//   - unchanged lines are skipped (not reprinted)
+//   - changed lines are reprinted with eraseLineRight
+func TestInlineRenderer_SecondRender_Changed(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewInlineRenderer(&buf, 80, 24)
+
+	// First render.
+	if err := r.Render("Hello\nWorld"); err != nil {
+		t.Fatalf("first Render error: %v", err)
+	}
+	buf.Reset()
+
+	// Second render: first line unchanged, second line changed.
+	if err := r.Render("Hello\nGoBrr"); err != nil {
+		t.Fatalf("second Render error: %v", err)
+	}
+
+	out := buf.String()
+
+	// Must contain cursor-up 1 line (linesRendered was 2, so 2-1=1).
+	if !strings.Contains(out, "\x1b[1A") {
+		t.Errorf("expected cursor-up 1, got: %q", out)
+	}
+
+	// Changed line must be present.
+	if !strings.Contains(out, "GoBrr") {
+		t.Errorf("changed line 'GoBrr' missing from output: %q", out)
+	}
+
+	// Unchanged line "Hello" should NOT be rewritten — only "\r\n" for advance.
+	// We verify by checking "Hello" is absent from the second render output.
+	if strings.Contains(out, "Hello") {
+		t.Errorf("unchanged line 'Hello' should be skipped, got: %q", out)
+	}
+
+	// Changed line must have eraseLineRight.
+	if !strings.Contains(out, "GoBrr"+eraseLineRight) {
+		t.Errorf("changed line should have eraseLineRight appended: %q", out)
+	}
+}
+
+// TestInlineRenderer_SecondRender_AllChanged verifies that when all lines
+// change, all are reprinted.
+func TestInlineRenderer_SecondRender_AllChanged(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewInlineRenderer(&buf, 80, 24)
+
+	if err := r.Render("Line1\nLine2"); err != nil {
+		t.Fatalf("first Render error: %v", err)
+	}
+	buf.Reset()
+
+	if err := r.Render("New1\nNew2"); err != nil {
+		t.Fatalf("second Render error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "New1") {
+		t.Errorf("expected 'New1' in output: %q", out)
+	}
+	if !strings.Contains(out, "New2") {
+		t.Errorf("expected 'New2' in output: %q", out)
+	}
+}
+
+// ─── Identical render (no-op) ─────────────────────────────────────────────────
+
+// TestInlineRenderer_IdenticalRender verifies that rendering the exact same
+// view twice results in no output on the second call.
+func TestInlineRenderer_IdenticalRender(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewInlineRenderer(&buf, 80, 24)
+
+	view := "Count: 5\nStatus: ok"
+
+	if err := r.Render(view); err != nil {
+		t.Fatalf("first Render error: %v", err)
+	}
+	buf.Reset()
+
+	if err := r.Render(view); err != nil {
+		t.Fatalf("second Render error: %v", err)
+	}
+
+	// No output for identical render.
+	if buf.Len() != 0 {
+		t.Errorf("identical render should produce no output, got: %q", buf.String())
+	}
+}
+
+// ─── View shrinks ────────────────────────────────────────────────────────────
+
+// TestInlineRenderer_ViewShrinks verifies that when the new view has fewer
+// lines than the previous render, eraseScreenBelow is emitted to clear the
+// leftover lines.
+func TestInlineRenderer_ViewShrinks(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewInlineRenderer(&buf, 80, 24)
+
+	// First render: 3 lines.
+	if err := r.Render("Line1\nLine2\nLine3"); err != nil {
+		t.Fatalf("first Render error: %v", err)
+	}
+	buf.Reset()
+
+	// Second render: 1 line.
+	if err := r.Render("Short"); err != nil {
+		t.Fatalf("second Render error: %v", err)
+	}
+
+	out := buf.String()
+
+	// Must erase extra lines below.
+	if !strings.Contains(out, eraseScreenBelow) {
+		t.Errorf("expected eraseScreenBelow (%q) when view shrinks: %q", eraseScreenBelow, out)
+	}
+
+	// linesRendered updated to new count.
+	if r.linesRendered != 1 {
+		t.Errorf("linesRendered: want 1, got %d", r.linesRendered)
+	}
+}
+
+// ─── View grows ──────────────────────────────────────────────────────────────
+
+// TestInlineRenderer_ViewGrows verifies that when the new view has more lines
+// than the previous render, all new lines are rendered without eraseScreenBelow.
+func TestInlineRenderer_ViewGrows(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewInlineRenderer(&buf, 80, 24)
+
+	// First render: 1 line.
+	if err := r.Render("Short"); err != nil {
+		t.Fatalf("first Render error: %v", err)
+	}
+	buf.Reset()
+
+	// Second render: 3 lines.
+	if err := r.Render("Line1\nLine2\nLine3"); err != nil {
+		t.Fatalf("second Render error: %v", err)
+	}
+
+	out := buf.String()
+
+	// All three lines present.
+	if !strings.Contains(out, "Line2") {
+		t.Errorf("expected 'Line2' in output: %q", out)
+	}
+	if !strings.Contains(out, "Line3") {
+		t.Errorf("expected 'Line3' in output: %q", out)
+	}
+
+	// No eraseScreenBelow when view grows.
+	if strings.Contains(out, eraseScreenBelow) {
+		t.Errorf("should not erase screen below when view grows: %q", out)
+	}
+
+	if r.linesRendered != 3 {
+		t.Errorf("linesRendered: want 3, got %d", r.linesRendered)
+	}
+}
+
+// ─── Empty view ──────────────────────────────────────────────────────────────
+
+// TestInlineRenderer_EmptyView verifies that an empty view is handled
+// gracefully and does not panic or produce corrupt sequences.
+func TestInlineRenderer_EmptyView(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewInlineRenderer(&buf, 80, 24)
+
+	if err := r.Render(""); err != nil {
+		t.Fatalf("Render empty view error: %v", err)
+	}
+
+	// linesRendered must be 1 (strings.Split("", "\n") = []string{""}).
+	if r.linesRendered != 1 {
+		t.Errorf("linesRendered for empty view: want 1, got %d", r.linesRendered)
+	}
+}
+
+// TestInlineRenderer_EmptyView_AfterContent verifies that rendering an empty
+// view after real content erases the previous output.
+func TestInlineRenderer_EmptyView_AfterContent(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewInlineRenderer(&buf, 80, 24)
+
+	if err := r.Render("Hello\nWorld\nEnd"); err != nil {
+		t.Fatalf("first Render error: %v", err)
+	}
+	buf.Reset()
+
+	if err := r.Render(""); err != nil {
+		t.Fatalf("second Render empty error: %v", err)
+	}
+
+	out := buf.String()
+
+	// 3 previous lines → 1 new line: must erase below.
+	if !strings.Contains(out, eraseScreenBelow) {
+		t.Errorf("expected eraseScreenBelow after switching to empty view: %q", out)
+	}
+}
+
+// ─── Resize ──────────────────────────────────────────────────────────────────
+
+// TestInlineRenderer_Resize verifies that Resize updates dimensions and forces
+// a full repaint (diff cache cleared) on the next Render.
+func TestInlineRenderer_Resize(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewInlineRenderer(&buf, 80, 24)
+
+	view := "Hello\nWorld"
+	if err := r.Render(view); err != nil {
+		t.Fatalf("first Render error: %v", err)
+	}
+	buf.Reset()
+
+	r.Resize(120, 40)
+
+	if r.width != 120 {
+		t.Errorf("width after Resize: want 120, got %d", r.width)
+	}
+	if r.height != 40 {
+		t.Errorf("height after Resize: want 40, got %d", r.height)
+	}
+
+	// Diff cache must be cleared.
+	if r.lastView != "" {
+		t.Error("lastView should be empty after Resize")
+	}
+	if r.lastLines != nil {
+		t.Error("lastLines should be nil after Resize")
+	}
+
+	// Re-render identical view — should produce output because cache is cleared.
+	if err := r.Render(view); err != nil {
+		t.Fatalf("Render after Resize error: %v", err)
+	}
+
+	if buf.Len() == 0 {
+		t.Error("Render after Resize should produce output (full repaint)")
+	}
+}
+
+// ─── Repaint ─────────────────────────────────────────────────────────────────
+
+// TestInlineRenderer_Repaint verifies that Repaint clears the diff cache so
+// the next Render performs a full repaint.
+func TestInlineRenderer_Repaint(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewInlineRenderer(&buf, 80, 24)
+
+	view := "Hello\nWorld"
+	if err := r.Render(view); err != nil {
+		t.Fatalf("first Render error: %v", err)
+	}
+	buf.Reset()
+
+	r.Repaint()
+
+	if r.lastView != "" {
+		t.Error("lastView should be empty after Repaint")
+	}
+	if r.lastLines != nil {
+		t.Error("lastLines should be nil after Repaint")
+	}
+
+	// linesRendered must NOT be reset by Repaint (cursor position still valid).
+	if r.linesRendered != 2 {
+		t.Errorf("linesRendered should remain 2 after Repaint, got %d", r.linesRendered)
+	}
+
+	// Re-render same view — should produce output (full repaint triggered).
+	if err := r.Render(view); err != nil {
+		t.Fatalf("Render after Repaint error: %v", err)
+	}
+
+	if buf.Len() == 0 {
+		t.Error("Render after Repaint should produce output")
+	}
+
+	// Content must be present after full repaint.
+	out := buf.String()
+	if !strings.Contains(out, "Hello") {
+		t.Errorf("expected 'Hello' after Repaint: %q", out)
+	}
+}
+
+// TestInlineRenderer_Repaint_DoesNotResetLinesRendered confirms linesRendered
+// is preserved so the cursor-up on the next flush is still correct.
+func TestInlineRenderer_Repaint_DoesNotResetLinesRendered(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewInlineRenderer(&buf, 80, 24)
+
+	if err := r.Render("A\nB\nC"); err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+	if r.linesRendered != 3 {
+		t.Fatalf("linesRendered before Repaint: want 3, got %d", r.linesRendered)
+	}
+
+	r.Repaint()
+
+	if r.linesRendered != 3 {
+		t.Errorf("linesRendered after Repaint: want 3, got %d", r.linesRendered)
+	}
+}
+
+// ─── SetOutput ───────────────────────────────────────────────────────────────
+
+// TestInlineRenderer_SetOutput verifies that SetOutput changes the destination
+// writer for future renders.
+func TestInlineRenderer_SetOutput(t *testing.T) {
+	var buf1, buf2 bytes.Buffer
+	r := NewInlineRenderer(&buf1, 80, 24)
+
+	if err := r.Render("First"); err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+
+	if buf1.Len() == 0 {
+		t.Fatal("buf1 should have received output")
+	}
+
+	r.SetOutput(&buf2)
+	r.Repaint()
+
+	if err := r.Render("Second"); err != nil {
+		t.Fatalf("Render after SetOutput error: %v", err)
+	}
+
+	if buf2.Len() == 0 {
+		t.Error("buf2 should have received output after SetOutput")
+	}
+	if !strings.Contains(buf2.String(), "Second") {
+		t.Errorf("buf2 should contain 'Second': %q", buf2.String())
+	}
+}
+
+// ─── Height clipping ─────────────────────────────────────────────────────────
+
+// TestInlineRenderer_HeightClipping verifies that a view taller than the
+// terminal height is clipped from the top, preserving the bottom lines.
+func TestInlineRenderer_HeightClipping(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewInlineRenderer(&buf, 80, 3) // only 3 lines tall
+
+	// 5-line view.
+	view := "L1\nL2\nL3\nL4\nL5"
+	if err := r.Render(view); err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+
+	out := buf.String()
+
+	// Bottom 3 lines should be present.
+	if !strings.Contains(out, "L3") {
+		t.Errorf("expected 'L3' in clipped output: %q", out)
+	}
+	if !strings.Contains(out, "L5") {
+		t.Errorf("expected 'L5' in clipped output: %q", out)
+	}
+
+	// Top 2 lines should be absent.
+	if strings.Contains(out, "L1") {
+		t.Errorf("'L1' should be clipped: %q", out)
+	}
+	if strings.Contains(out, "L2") {
+		t.Errorf("'L2' should be clipped: %q", out)
+	}
+
+	// linesRendered must be 3 (the clipped height), not 5.
+	if r.linesRendered != 3 {
+		t.Errorf("linesRendered after clipping: want 3, got %d", r.linesRendered)
+	}
+}
+
+// TestInlineRenderer_ZeroHeight verifies that height=0 disables clipping.
+func TestInlineRenderer_ZeroHeight(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewInlineRenderer(&buf, 80, 0) // height 0 = no clipping
+
+	view := "L1\nL2\nL3\nL4\nL5"
+	if err := r.Render(view); err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+
+	out := buf.String()
+
+	// All lines present.
+	for _, line := range []string{"L1", "L2", "L3", "L4", "L5"} {
+		if !strings.Contains(out, line) {
+			t.Errorf("expected %q in output with zero height: %q", line, out)
+		}
+	}
+
+	if r.linesRendered != 5 {
+		t.Errorf("linesRendered: want 5, got %d", r.linesRendered)
+	}
+}
+
+// ─── Width truncation ─────────────────────────────────────────────────────────
+
+// TestInlineRenderer_WidthTruncation verifies that lines longer than the
+// terminal width are truncated.
+func TestInlineRenderer_WidthTruncation(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewInlineRenderer(&buf, 5, 24) // only 5 columns wide
+
+	if err := r.Render("Hello World"); err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+
+	out := buf.String()
+
+	// "Hello" fits in 5 columns; " World" should be cut off.
+	if strings.Contains(out, "World") {
+		t.Errorf("'World' should be truncated: %q", out)
+	}
+	if !strings.Contains(out, "Hello") {
+		t.Errorf("'Hello' should be present: %q", out)
+	}
+}
+
+// TestInlineRenderer_ZeroWidth verifies that width=0 disables truncation.
+func TestInlineRenderer_ZeroWidth(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewInlineRenderer(&buf, 0, 24) // width 0 = no truncation
+
+	long := strings.Repeat("X", 200)
+	if err := r.Render(long); err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+
+	// Full line should be present.
+	if !strings.Contains(buf.String(), long) {
+		t.Errorf("line should not be truncated with width=0")
+	}
+}
+
+// ─── Write error propagation ──────────────────────────────────────────────────
+
+// TestInlineRenderer_WriteError verifies that a write error is returned from
+// Render and that internal state is not updated (failed render is retryable).
+func TestInlineRenderer_WriteError(t *testing.T) {
+	r := NewInlineRenderer(&errorWriter{}, 80, 24)
+
+	err := r.Render("Hello")
+	if err == nil {
+		t.Fatal("expected write error, got nil")
+	}
+
+	// State must not be updated on error.
+	if r.linesRendered != 0 {
+		t.Errorf("linesRendered should be 0 after failed write, got %d", r.linesRendered)
+	}
+	if r.lastView != "" {
+		t.Errorf("lastView should be empty after failed write, got %q", r.lastView)
+	}
+}
+
+// errorWriter always returns an error on Write.
+type errorWriter struct{}
+
+func (errorWriter) Write(_ []byte) (int, error) {
+	return 0, &writeError{}
+}
+
+type writeError struct{}
+
+func (writeError) Error() string { return "simulated write error" }
+
+// ─── Concurrent access ────────────────────────────────────────────────────────
+
+// TestInlineRenderer_ConcurrentAccess verifies that the mutex protects
+// concurrent calls to Render, Repaint, Resize, and SetOutput.
+func TestInlineRenderer_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+	var buf syncBuffer
+	r := NewInlineRenderer(&buf, 80, 24)
+
+	var wg sync.WaitGroup
+	const goroutines = 20
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			switch n % 4 {
+			case 0:
+				_ = r.Render("Hello\nWorld")
+			case 1:
+				r.Repaint()
+			case 2:
+				r.Resize(80, 24)
+			case 3:
+				r.SetOutput(&buf)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	// No data race or panic = pass.
+}
+
+// syncBuffer is a bytes.Buffer protected by a mutex, suitable for concurrent writes.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+// ─── Internal helper tests ────────────────────────────────────────────────────
+
+// TestStripANSI verifies ANSI escape sequence removal.
+func TestStripANSI(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"Hello", "Hello"},
+		{"\x1b[31mRed\x1b[0m", "Red"},
+		{"\x1b[1;32mBold Green\x1b[0m", "Bold Green"},
+		{"No escapes", "No escapes"},
+		{"\x1b[K", ""},
+		{"\x1b[J", ""},
+		{"\x1b[2A", ""},
+		{"Hello\x1b[K World", "Hello World"},
+	}
+
+	for _, c := range cases {
+		got := stripANSI(c.input)
+		if got != c.want {
+			t.Errorf("stripANSI(%q) = %q, want %q", c.input, got, c.want)
+		}
+	}
+}
+
+// TestVisualWidth verifies column-width calculation.
+func TestVisualWidth(t *testing.T) {
+	cases := []struct {
+		input string
+		want  int
+	}{
+		{"Hello", 5},
+		{"", 0},
+		{"\x1b[31mHello\x1b[0m", 5}, // ANSI codes ignored
+		{"日本語", 6},                  // 3 × 2 columns
+		{"A日B", 4},                  // 1 + 2 + 1
+	}
+
+	for _, c := range cases {
+		got := visualWidth(c.input)
+		if got != c.want {
+			t.Errorf("visualWidth(%q) = %d, want %d", c.input, got, c.want)
+		}
+	}
+}
+
+// TestTruncateLine verifies line truncation respects display width.
+func TestTruncateLine(t *testing.T) {
+	cases := []struct {
+		input    string
+		maxWidth int
+		wantLen  int // expected visual width of result
+		wantHas  string
+		wantNot  string
+	}{
+		{"Hello World", 5, 5, "Hello", "World"},
+		{"Hello", 10, 5, "Hello", ""}, // shorter than max — unchanged
+		{"Hello", 5, 5, "Hello", ""},  // exactly max — unchanged
+		{"日本語", 4, 4, "日本", "語"},      // wide chars
+		{"A日B", 3, 3, "A日", "B"},      // mixed
+	}
+
+	for _, c := range cases {
+		got := truncateLine(c.input, c.maxWidth)
+		gotWidth := visualWidth(got)
+		if gotWidth > c.maxWidth {
+			t.Errorf("truncateLine(%q, %d) visual width %d > max %d; got %q",
+				c.input, c.maxWidth, gotWidth, c.maxWidth, got)
+		}
+		if gotWidth != c.wantLen {
+			t.Errorf("truncateLine(%q, %d) width = %d, want %d; got %q",
+				c.input, c.maxWidth, gotWidth, c.wantLen, got)
+		}
+		if c.wantHas != "" && !strings.Contains(got, c.wantHas) {
+			t.Errorf("truncateLine(%q, %d) should contain %q; got %q",
+				c.input, c.maxWidth, c.wantHas, got)
+		}
+		if c.wantNot != "" && strings.Contains(got, c.wantNot) {
+			t.Errorf("truncateLine(%q, %d) should not contain %q; got %q",
+				c.input, c.maxWidth, c.wantNot, got)
+		}
+	}
+}
+
+// TestTruncateLine_PreservesANSI verifies that ANSI escape sequences are passed
+// through without counting toward the width budget.
+func TestTruncateLine_PreservesANSI(t *testing.T) {
+	// Red "Hello" followed by reset — visual width is 5 but string is longer.
+	input := "\x1b[31mHello\x1b[0m World"
+	got := truncateLine(input, 5)
+
+	// Visual width must not exceed 5.
+	if w := visualWidth(got); w > 5 {
+		t.Errorf("visual width after truncation = %d, want <= 5; got %q", w, got)
+	}
+
+	// ANSI codes should still be present in the output.
+	if !strings.Contains(got, "\x1b[31m") {
+		t.Errorf("ANSI opening sequence should be preserved: %q", got)
+	}
+}
+
+// ─── Sequence correctness ─────────────────────────────────────────────────────
+
+// TestInlineRenderer_CursorUpCorrectness verifies the exact cursor-up count
+// for multi-line renders.
+func TestInlineRenderer_CursorUpCorrectness(t *testing.T) {
+	cases := []struct {
+		firstView  string
+		secondView string
+		wantUp     string // expected cursor-up sequence, empty = none
+	}{
+		{"A", "B", ""},                    // 1 line → no cursor-up
+		{"A\nB", "C\nD", "\x1b[1A"},       // 2 lines → cursor-up 1
+		{"A\nB\nC", "D\nE\nF", "\x1b[2A"}, // 3 lines → cursor-up 2
+	}
+
+	for _, c := range cases {
+		var buf bytes.Buffer
+		r := NewInlineRenderer(&buf, 80, 24)
+
+		if err := r.Render(c.firstView); err != nil {
+			t.Fatalf("first Render error: %v", err)
+		}
+		buf.Reset()
+
+		if err := r.Render(c.secondView); err != nil {
+			t.Fatalf("second Render error: %v", err)
+		}
+
+		out := buf.String()
+		if c.wantUp == "" {
+			hasCursorUp := strings.Contains(out, "\x1b[1A") || strings.Contains(out, "\x1b[2A")
+			if hasCursorUp {
+				t.Errorf("firstView=%q → secondView=%q: unexpected cursor-up in %q",
+					c.firstView, c.secondView, out)
+			}
+			continue
+		}
+		if !strings.Contains(out, c.wantUp) {
+			t.Errorf("firstView=%q → secondView=%q: want cursor-up %q, got %q",
+				c.firstView, c.secondView, c.wantUp, out)
+		}
+	}
+}
+
+// ─── cursorUp edge cases ──────────────────────────────────────────────────────
+
+// TestCursorUp verifies the helper function for cursor-up sequences.
+func TestCursorUp(t *testing.T) {
+	cases := []struct {
+		n    int
+		want string
+	}{
+		{0, ""},
+		{-1, ""},
+		{-100, ""},
+		{1, "\x1b[1A"},
+		{5, "\x1b[5A"},
+		{100, "\x1b[100A"},
+	}
+	for _, c := range cases {
+		got := cursorUp(c.n)
+		if got != c.want {
+			t.Errorf("cursorUp(%d) = %q, want %q", c.n, got, c.want)
+		}
+	}
+}
+
+// ─── stripANSI additional coverage ───────────────────────────────────────────
+
+// TestStripANSI_OSC verifies that OSC sequences (window title etc.) are stripped.
+func TestStripANSI_OSC(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		// OSC terminated by BEL
+		{"\x1b]0;Title\x07Text", "Text"},
+		// OSC terminated by ST (ESC \)
+		{"\x1b]0;Title\x1b\\Text", "Text"},
+		// Bare ESC at end of string
+		{"\x1b", ""},
+		// Two-byte ESC sequences (not CSI)
+		{"\x1b7Text\x1b8", "Text"},
+		// ESC at end of string (truncated)
+		{"Hello\x1b", "Hello"},
+	}
+	for _, c := range cases {
+		got := stripANSI(c.input)
+		if got != c.want {
+			t.Errorf("stripANSI(%q) = %q, want %q", c.input, got, c.want)
+		}
+	}
+}
+
+// ─── decodeRune coverage ──────────────────────────────────────────────────────
+
+// TestDecodeRune verifies UTF-8 rune decoding including error cases.
+func TestDecodeRune(t *testing.T) {
+	cases := []struct {
+		s        string
+		i        int
+		wantRune rune
+		wantSize int
+	}{
+		// ASCII
+		{"Hello", 0, 'H', 1},
+		{"Hello", 4, 'o', 1},
+		// 2-byte UTF-8 (é = U+00E9)
+		{"\xc3\xa9", 0, 'é', 2},
+		// 3-byte UTF-8 (日 = U+65E5)
+		{"\xe6\x97\xa5", 0, '日', 3},
+		// 4-byte UTF-8 (𝄞 = U+1D11E)
+		{"\xf0\x9d\x84\x9e", 0, '𝄞', 4},
+		// Invalid lead byte
+		{"\xff", 0, '\uFFFD', 1},
+		// Truncated 2-byte sequence
+		{"\xc3", 0, '\uFFFD', 1},
+		// Invalid continuation byte
+		{"\xc3\x00", 0, '\uFFFD', 1},
+	}
+
+	for _, c := range cases {
+		gotRune, gotSize := decodeRune(c.s, c.i)
+		if gotRune != c.wantRune {
+			t.Errorf("decodeRune(%q, %d) rune = %q (%d), want %q (%d)",
+				c.s, c.i, gotRune, gotRune, c.wantRune, c.wantRune)
+		}
+		if gotSize != c.wantSize {
+			t.Errorf("decodeRune(%q, %d) size = %d, want %d",
+				c.s, c.i, gotSize, c.wantSize)
+		}
+	}
+}
+
+// ─── runeDisplayWidth coverage ────────────────────────────────────────────────
+
+// TestRuneDisplayWidth verifies display width for representative Unicode ranges.
+func TestRuneDisplayWidth(t *testing.T) {
+	cases := []struct {
+		r    rune
+		want int
+		desc string
+	}{
+		// ASCII printable
+		{'A', 1, "ASCII letter"},
+		{' ', 1, "ASCII space"},
+		// Control characters
+		{'\n', 0, "newline"},
+		{'\t', 0, "tab"},
+		{'\x1b', 0, "ESC"},
+		{'\x80', 0, "C1 control start"},
+		{'\x9F', 0, "C1 control end"},
+		// Hangul Jamo (wide)
+		{'\u1100', 2, "Hangul Jamo start"},
+		{'\u115F', 2, "Hangul Jamo end"},
+		// Angle brackets (wide)
+		{'\u2329', 2, "left angle bracket"},
+		{'\u232A', 2, "right angle bracket"},
+		// CJK Radicals (wide)
+		{'\u2E80', 2, "CJK Radicals start"},
+		// Japanese Hiragana (wide)
+		{'\u3041', 2, "Hiragana"},
+		// CJK Extension A (wide)
+		{'\u3400', 2, "CJK Ext-A start"},
+		// CJK Unified Ideographs (wide)
+		{'\u4E00', 2, "CJK start"},
+		{'\u9FFF', 2, "CJK end area"},
+		// Hangul Extended-A (wide)
+		{'\uA960', 2, "Hangul Ext-A"},
+		// Hangul Syllables (wide)
+		{'\uAC00', 2, "Hangul Syllables start"},
+		// CJK Compatibility Ideographs (wide)
+		{'\uF900', 2, "CJK Compat start"},
+		// Vertical forms (wide)
+		{'\uFE10', 2, "Vertical forms start"},
+		// CJK Compat Forms (wide)
+		{'\uFE30', 2, "CJK Compat Forms start"},
+		// Fullwidth Forms (wide)
+		{'\uFF01', 2, "Fullwidth exclamation"},
+		// Fullwidth Signs (wide)
+		{'\uFFE0', 2, "Fullwidth signs start"},
+		// Emoji (wide)
+		{'\U0001F600', 2, "Emoji grinning face"},
+		// Combining mark (zero width)
+		{'\u0300', 0, "combining grave accent"},
+		// Regular Latin (1 column)
+		{'z', 1, "Latin small z"},
+	}
+
+	for _, c := range cases {
+		got := runeDisplayWidth(c.r)
+		if got != c.want {
+			t.Errorf("runeDisplayWidth(%q %s U+%04X) = %d, want %d",
+				c.r, c.desc, c.r, got, c.want)
+		}
+	}
+}
+
+// TestRuneDisplayWidth_AdditionalRanges covers ranges not hit by the basic test.
+func TestRuneDisplayWidth_AdditionalRanges(t *testing.T) {
+	cases := []struct {
+		r    rune
+		want int
+	}{
+		// Kana Supplement
+		{'\U0001B000', 2},
+		// Playing cards / Mahjong tiles
+		{'\U0001F004', 2},
+		// CJK Extension B-F
+		{'\U00020000', 2},
+		{'\U0002FFFD', 2},
+		// CJK Extension G+
+		{'\U00030000', 2},
+		{'\U0003FFFD', 2},
+		// Normal Latin character (should be 1, not wide)
+		{'a', 1},
+	}
+
+	for _, c := range cases {
+		got := runeDisplayWidth(c.r)
+		if got != c.want {
+			t.Errorf("runeDisplayWidth(U+%04X) = %d, want %d", c.r, got, c.want)
+		}
+	}
+}
+
+// ─── truncateLine OSC coverage ───────────────────────────────────────────────
+
+// TestTruncateLine_OSCSequence verifies that OSC sequences in a line are
+// passed through without counting toward the width budget.
+func TestTruncateLine_OSCSequence(t *testing.T) {
+	// OSC window title followed by visible text
+	input := "\x1b]0;Title\x07Hello World"
+	got := truncateLine(input, 5)
+
+	// Visual width must not exceed 5.
+	if w := visualWidth(got); w > 5 {
+		t.Errorf("visual width = %d, want <= 5; got %q", w, got)
+	}
+	// "Hello" should be present.
+	if !strings.Contains(got, "Hello") {
+		t.Errorf("expected 'Hello' in output: %q", got)
+	}
+	// OSC sequence should be preserved.
+	if !strings.Contains(got, "\x1b]0;Title\x07") {
+		t.Errorf("OSC sequence should be preserved: %q", got)
+	}
+}
+
+// TestTruncateLine_TwoByteESC verifies two-byte ESC sequences (e.g., DECSC)
+// are passed through without counting toward the width budget.
+func TestTruncateLine_TwoByteESC(t *testing.T) {
+	// DECSC (save cursor) + text
+	input := "\x1b7Hello World\x1b8"
+	got := truncateLine(input, 5)
+
+	if w := visualWidth(got); w > 5 {
+		t.Errorf("visual width = %d, want <= 5; got %q", w, got)
+	}
+	if !strings.Contains(got, "Hello") {
+		t.Errorf("expected 'Hello' in output: %q", got)
+	}
+}
+
+// TestTruncateLine_ESCAtEndOfString verifies truncateLine handles a trailing
+// ESC byte gracefully.
+func TestTruncateLine_ESCAtEndOfString(t *testing.T) {
+	input := "Hi\x1b"
+	// Should not panic; result may or may not include trailing ESC.
+	got := truncateLine(input, 80)
+	if !strings.HasPrefix(got, "Hi") {
+		t.Errorf("expected result to start with 'Hi': %q", got)
+	}
+}
+
+// TestTruncateLine_OSCSequence_STTerminated verifies that OSC sequences
+// terminated by ST (ESC \) are handled correctly in truncateLine.
+func TestTruncateLine_OSCSequence_STTerminated(t *testing.T) {
+	// OSC terminated by String Terminator (ESC \)
+	input := "\x1b]0;Title\x1b\\Hello World"
+	got := truncateLine(input, 5)
+
+	if w := visualWidth(got); w > 5 {
+		t.Errorf("visual width = %d, want <= 5; got %q", w, got)
+	}
+	if !strings.Contains(got, "Hello") {
+		t.Errorf("expected 'Hello' in output: %q", got)
+	}
+}
+
+// TestTruncateLine_ESCAtEnd_Short verifies the path where ESC appears
+// at the end of the string in the main loop of truncateLine.
+func TestTruncateLine_ESCAtEnd_Short(t *testing.T) {
+	// String that is shorter than maxWidth but ends with ESC — should return unchanged.
+	input := "Hi\x1b"
+	got := truncateLine(input, 2) // visual width 2 = "Hi", but ESC is still there in original
+	// visualWidth("Hi\x1b") strips ANSI → "Hi" = 2 columns which equals maxWidth.
+	// So the early-return branch fires and we get the original string back.
+	if got != input {
+		t.Errorf("truncateLine(%q, 2): expected original string back (fits in maxWidth), got %q", input, got)
+	}
+}

--- a/terminal/README.md
+++ b/terminal/README.md
@@ -1,37 +1,31 @@
 # Phoenix Terminal - Platform-Optimized Terminal Operations
 
-**Status**: Week 15 Complete - ANSI Baseline Implementation ✅
-**Coverage**: 93.0% (exceeds 90% target) ⭐
-**Version**: v0.1.0-alpha (Week 15)
+**Module**: `github.com/phoenix-tui/phoenix/terminal`
 
 Phoenix Terminal provides a platform-abstraction layer for terminal operations with automatic detection and optimized implementations for each platform.
 
 ## Features
 
-### Week 15 (Current) - ANSI Baseline
+- **Complete Terminal API** - All operations defined and documented
+- **ANSI Implementation** - Universal fallback for Unix/Linux/macOS/Git Bash
+- **Auto-Detection** - Automatic platform detection
+- **ClearLines()** - Critical multiline clearing operation
+- **Rich Documentation** - Complete godoc and usage examples
+- **Extensive test coverage** - Comprehensive unit and benchmark tests
 
-- ✅ **Complete Terminal API** - All operations defined and documented
-- ✅ **ANSI Implementation** - Universal fallback for Unix/Linux/macOS/Git Bash
-- ✅ **93.0% Test Coverage** - Comprehensive unit and benchmark tests
-- ✅ **Auto-Detection** - Automatic platform detection (returns ANSI in Week 15)
-- ✅ **ClearLines()** - Critical multiline clearing operation
-- ✅ **Rich Documentation** - Complete godoc and usage examples
+### Planned
 
-### Week 16 (Coming) - Windows Console API
-
-- 🎯 **Windows Console API** - Direct Win32 calls (10x faster!)
-- 🎯 **Auto-Fallback** - Git Bash detection → ANSI fallback
-- 🎯 **Cursor Readback** - GetCursorPosition() support
-- 🎯 **Screen Buffer Readback** - ReadScreenBuffer() for differential rendering
-- 🎯 **Performance Benchmarks** - ANSI vs Windows API comparison
+- **Windows Console API** - Direct Win32 calls for faster performance
+- **Auto-Fallback** - Git Bash detection with ANSI fallback
+- **Cursor Readback** - GetCursorPosition() support
+- **Screen Buffer Readback** - ReadScreenBuffer() for differential rendering
 
 ## Quick Start
 
 ### Installation
 
 ```bash
-cd D:\projects\grpmsoft\tui
-go work use ./terminal
+go get github.com/phoenix-tui/phoenix/terminal
 ```
 
 ### Basic Usage
@@ -75,7 +69,7 @@ go run main.go
 ### Constructors
 
 ```go
-// Auto-detect platform (Week 15: returns ANSI, Week 16: Windows API or ANSI)
+// Auto-detect platform (returns best available implementation)
 term := infrastructure.NewTerminal()
 
 // Force ANSI implementation (for testing or compatibility)
@@ -88,7 +82,7 @@ term := infrastructure.NewANSITerminal()
 // Absolute positioning (0-based coordinates)
 term.SetCursorPosition(x, y int) error
 
-// Cursor position readback (Week 16 only - Windows Console API)
+// Cursor position readback (Windows Console API only)
 x, y, err := term.GetCursorPosition() // Returns error on ANSI
 
 // Relative movements
@@ -137,7 +131,7 @@ term.Write(s string) error
 term.WriteAt(x, y int, s string) error
 ```
 
-### Screen Buffer (Week 16 - Windows Console API only)
+### Screen Buffer (Windows Console API only)
 
 ```go
 // Read screen buffer for differential rendering
@@ -166,24 +160,24 @@ supportsTrueColor := term.SupportsTrueColor()        // true if 24-bit RGB
 // Platform type
 platform := term.Platform()
 // api.PlatformUnix - Linux/macOS/Git Bash (ANSI)
-// api.PlatformWindowsConsole - cmd.exe/PowerShell (Win32 API) - Week 16
-// api.PlatformWindowsANSI - Git Bash on Windows (ANSI fallback) - Week 16
+// api.PlatformWindowsConsole - cmd.exe/PowerShell (Win32 API)
+// api.PlatformWindowsANSI - Git Bash on Windows (ANSI fallback)
 ```
 
 ## Platform Support Matrix
 
-| Platform | Week 15 (ANSI) | Week 16 (Optimized) |
-|----------|----------------|---------------------|
-| Linux | ✅ ANSI | ✅ ANSI |
-| macOS | ✅ ANSI | ✅ ANSI |
-| Windows (cmd.exe) | ✅ ANSI | 🎯 Win32 API (10x faster) |
-| Windows (PowerShell) | ✅ ANSI | 🎯 Win32 API (10x faster) |
-| Windows (Git Bash) | ✅ ANSI | ✅ ANSI (auto-fallback) |
-| Windows (WSL) | ✅ ANSI | ✅ ANSI |
+| Platform | ANSI | Optimized (Windows API) |
+|----------|------|-------------------------|
+| Linux | Supported | N/A |
+| macOS | Supported | N/A |
+| Windows (cmd.exe) | Supported | Planned (Win32 API) |
+| Windows (PowerShell) | Supported | Planned (Win32 API) |
+| Windows (Git Bash) | Supported | ANSI (auto-fallback) |
+| Windows (WSL) | Supported | N/A |
 
 ## Performance
 
-### Week 15 Baseline (ANSI)
+### ANSI Baseline
 
 Benchmarks (on Windows Git Bash):
 
@@ -194,29 +188,28 @@ BenchmarkANSI_Write                ~50ns per operation
 BenchmarkANSI_WriteAt              ~150ns per operation
 ```
 
-### Week 16 Target (Windows Console API)
+### Windows Console API (Planned)
 
 Expected improvements on Windows (cmd.exe, PowerShell):
 
 | Operation | ANSI | Windows API | Speedup |
 |-----------|------|-------------|---------|
-| SetCursorPosition | ~100μs | ~10μs | 10x |
-| ClearLines(10) | ~500μs | ~50μs | 10x |
-| ReadScreenBuffer | N/A | ~1ms | ∞ |
+| SetCursorPosition | ~100us | ~10us | 10x |
+| ClearLines(10) | ~500us | ~50us | 10x |
+| ReadScreenBuffer | N/A | ~1ms | N/A |
 
 ## Testing
 
 ### Run Tests
 
 ```bash
-cd D:\projects\grpmsoft\tui\terminal
+cd terminal
 
 # All tests
 go test ./...
 
 # With coverage
 go test ./infrastructure/unix -cover
-# Output: coverage: 93.0% of statements ✅
 
 # Verbose output
 go test ./infrastructure/unix -v
@@ -224,15 +217,6 @@ go test ./infrastructure/unix -v
 # Benchmarks
 go test ./infrastructure/unix -bench=. -benchmem
 ```
-
-### Coverage Report
-
-```
-github.com/phoenix-tui/phoenix/terminal/infrastructure/unix
-    coverage: 93.0% of statements ✅
-```
-
-Exceeds Phoenix 90%+ target!
 
 ## Architecture
 
@@ -244,17 +228,17 @@ terminal/
 │   └── terminal.go         # Terminal interface (platform-independent)
 ├── infrastructure/
 │   ├── unix/
-│   │   ├── ansi.go         # ANSI implementation (Week 15) ✅
-│   │   └── ansi_test.go    # Comprehensive tests (93.0% coverage) ✅
-│   ├── windows/            # Windows Console API (Week 16) 🎯
+│   │   ├── ansi.go         # ANSI implementation
+│   │   └── ansi_test.go    # Comprehensive tests
+│   ├── windows/            # Windows Console API (planned)
 │   │   ├── console.go      # Win32 API calls
 │   │   └── console_test.go
 │   └── detect.go           # Auto-detection logic
 ├── examples/
 │   └── basic/
-│       └── main.go         # Demo application ✅
-├── go.mod                  # Module definition ✅
-└── README.md               # This file ✅
+│       └── main.go         # Demo application
+├── go.mod                  # Module definition
+└── README.md               # This file
 ```
 
 **Key Principles**:
@@ -265,7 +249,7 @@ terminal/
 
 ## ANSI Escape Codes Reference
 
-Week 15 implementation uses these ANSI codes:
+The ANSI implementation uses these escape codes:
 
 ```
 Cursor Positioning:
@@ -302,21 +286,21 @@ term.ClearLines(oldLineCount)
 term.Write(newContent)
 ```
 
-**ANSI Implementation** (Week 15):
+**ANSI Implementation**:
 ```
 count == 1: \r\033[J           (CR + clear to end)
 count > 1:  \033[{n-1}A\r\033[J (move up, CR, clear to end)
 ```
 
-**Windows API Implementation** (Week 16):
+**Windows API Implementation** (planned):
 ```go
-// Direct Win32 FillConsoleOutputCharacter() - 10x faster!
+// Direct Win32 FillConsoleOutputCharacter() - significantly faster
 windows.FillConsoleOutputCharacter(stdout, ' ', totalChars, startCoord, &written)
 ```
 
 ## Integration with GoSh
 
-GoSh multiline mode will use Phoenix Terminal in Week 16:
+GoSh multiline mode uses Phoenix Terminal for platform-optimized clearing:
 
 ```go
 // Before (manual ANSI codes):
@@ -329,33 +313,13 @@ fmt.Print("\r\033[J")
 term.ClearLines(len(lines))
 ```
 
-## Roadmap
-
-### ✅ Week 15 (Complete)
-- [x] Terminal interface definition
-- [x] ANSI implementation (all methods)
-- [x] Auto-detection (returns ANSI)
-- [x] Comprehensive tests (93.0% coverage)
-- [x] Benchmark tests
-- [x] Example application
-- [x] Documentation
-
-### 🎯 Week 16 (Next)
-- [ ] Windows Console API implementation
-- [ ] Windows detection logic
-- [ ] Auto-fallback (Windows API → Git Bash ANSI)
-- [ ] Cursor readback (GetCursorPosition)
-- [ ] Screen buffer readback (ReadScreenBuffer)
-- [ ] Performance benchmarks (ANSI vs Windows API)
-- [ ] GoSh integration
-
 ## Contributing
 
-This is part of Phoenix TUI Framework (Week 15-16).
+This is part of Phoenix TUI Framework.
 
 **Testing Requirements**:
 - Unit tests for all public methods
-- 90%+ coverage (Week 15: 93.0% ✅)
+- High test coverage target
 - Benchmark tests for performance tracking
 - Example applications that demonstrate usage
 
@@ -368,10 +332,3 @@ This is part of Phoenix TUI Framework (Week 15-16).
 ## License
 
 Part of Phoenix TUI Framework - See root LICENSE
-
----
-
-**Phoenix Terminal** - Building the foundation for 10x Windows performance! 🚀
-
-Week 15: ✅ ANSI Baseline (93.0% coverage)
-Week 16: 🎯 Windows Console API (10x faster!)


### PR DESCRIPTION
## Summary

- **InlineRenderer**: Non-alt-screen per-line diffing renderer with ANSI-preserving width truncation, height clipping, thread-safe design, 35 tests (99.4% coverage)
- **Program integration**: Lazy InlineRenderer init on first `View()`, automatic `WindowSizeMsg` forwarding, `Repaint()` on `Resume()`
- **Flaky test fixes**: Replace racy `inputReaderRunning` checks with race-free generation counter; remove all `t.Skip("flaky on Windows")` from exec_process and suspend_resume tests
- **Version-agnostic docs**: Remove hardcoded versions, week references, and coverage percentages from all README.md files
- **Architecture doc**: New public `docs/ARCHITECTURE.md` with Mermaid dependency graph and bounded contexts diagrams
- **CHANGELOG**: Add v0.2.4 section

## Test plan

- [ ] CI green on Linux, macOS, Windows
- [ ] No flaky test skips remaining
- [ ] `golangci-lint run ./...` passes on tea module
- [ ] InlineRenderer tests pass with `-race`
