### PR TITLE
chore: bump module versions to v0.2.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,23 +6,21 @@ name: Tests
 # - Go 1.25+ required (matches go.mod requirement)
 # - Multi-module monorepo: Each module tested independently with GOWORK=off
 #
-# Branch Strategy (Git Flow):
-# - release/** branches: Pre-release testing (test here BEFORE merging to main)
+# Branch Strategy:
 # - main branch: Production-ready code only (protected)
-# - develop branch: Active development (default for PRs)
-# - Pull requests: Must pass all tests before merge
+# - develop branch: Active development
+# - Pull requests to main/develop: Must pass all tests before merge
+# - Release branches: Tested via PR (no duplicate push trigger)
 
 on:
   push:
     branches:
       - main
       - develop
-      - 'release/**'  # Test release branches before merging to main
   pull_request:
     branches:
       - main
       - develop
-      - 'release/**'
 
 env:
   GOWORK: off  # Disable workspace mode in CI (workspaces are for local dev only)

--- a/benchmarks/comparison/go.mod
+++ b/benchmarks/comparison/go.mod
@@ -5,7 +5,7 @@ go 1.25.1
 require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/mattn/go-runewidth v0.0.19
-	github.com/phoenix-tui/phoenix/core v0.1.0-beta.3
+	github.com/phoenix-tui/phoenix/core v0.2.4
 )
 
 require (

--- a/clipboard/go.mod
+++ b/clipboard/go.mod
@@ -4,13 +4,13 @@ go 1.25.1
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/phoenix-tui/phoenix/tea v0.2.0
+	github.com/phoenix-tui/phoenix/tea v0.2.4
 	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/phoenix-tui/phoenix/terminal v0.2.0 // indirect
+	github.com/phoenix-tui/phoenix/terminal v0.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/term v0.39.0 // indirect

--- a/components/go.mod
+++ b/components/go.mod
@@ -3,18 +3,18 @@ module github.com/phoenix-tui/phoenix/components
 go 1.25.1
 
 require (
-	github.com/phoenix-tui/phoenix/tea v0.2.0
+	github.com/phoenix-tui/phoenix/tea v0.2.4
 	github.com/rivo/uniseg v0.4.7
 )
 
 require (
-	github.com/phoenix-tui/phoenix/core v0.2.0 // indirect
+	github.com/phoenix-tui/phoenix/core v0.2.4 // indirect
 	github.com/unilibs/uniwidth v0.2.0 // indirect
 )
 
 require (
-	github.com/phoenix-tui/phoenix/style v0.2.0
-	github.com/phoenix-tui/phoenix/terminal v0.2.0 // indirect
+	github.com/phoenix-tui/phoenix/style v0.2.4
+	github.com/phoenix-tui/phoenix/terminal v0.2.4 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/term v0.39.0 // indirect
 )

--- a/examples/cobra-cli/go.mod
+++ b/examples/cobra-cli/go.mod
@@ -15,16 +15,16 @@ replace github.com/phoenix-tui/phoenix/terminal => ../../terminal
 replace github.com/phoenix-tui/phoenix/testing => ../../testing
 
 require (
-	github.com/phoenix-tui/phoenix/components v0.2.0
-	github.com/phoenix-tui/phoenix/style v0.2.0
-	github.com/phoenix-tui/phoenix/tea v0.2.0
+	github.com/phoenix-tui/phoenix/components v0.2.4
+	github.com/phoenix-tui/phoenix/style v0.2.4
+	github.com/phoenix-tui/phoenix/tea v0.2.4
 	github.com/spf13/cobra v1.10.2
 )
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/phoenix-tui/phoenix/core v0.2.0 // indirect
-	github.com/phoenix-tui/phoenix/terminal v0.2.0 // indirect
+	github.com/phoenix-tui/phoenix/core v0.2.4 // indirect
+	github.com/phoenix-tui/phoenix/terminal v0.2.4 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/unilibs/uniwidth v0.2.0 // indirect

--- a/examples/context-menu/go.mod
+++ b/examples/context-menu/go.mod
@@ -15,14 +15,14 @@ replace github.com/phoenix-tui/phoenix/terminal => ../../terminal
 replace github.com/phoenix-tui/phoenix/testing => ../../testing
 
 require (
-	github.com/phoenix-tui/phoenix/mouse v0.0.0
-	github.com/phoenix-tui/phoenix/style v0.0.0
-	github.com/phoenix-tui/phoenix/tea v0.0.0
+	github.com/phoenix-tui/phoenix/mouse v0.2.4
+	github.com/phoenix-tui/phoenix/style v0.2.4
+	github.com/phoenix-tui/phoenix/tea v0.2.4
 )
 
 require (
-	github.com/phoenix-tui/phoenix/core v0.2.0 // indirect
-	github.com/phoenix-tui/phoenix/terminal v0.2.0 // indirect
+	github.com/phoenix-tui/phoenix/core v0.2.4 // indirect
+	github.com/phoenix-tui/phoenix/terminal v0.2.4 // indirect
 	github.com/unilibs/uniwidth v0.2.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/term v0.39.0 // indirect

--- a/examples/drag-scroll/go.mod
+++ b/examples/drag-scroll/go.mod
@@ -15,14 +15,14 @@ replace github.com/phoenix-tui/phoenix/style => ../../style
 replace github.com/phoenix-tui/phoenix/testing => ../../testing
 
 require (
-	github.com/phoenix-tui/phoenix/components v0.1.0-beta.4
-	github.com/phoenix-tui/phoenix/tea v0.2.0
+	github.com/phoenix-tui/phoenix/components v0.2.4
+	github.com/phoenix-tui/phoenix/tea v0.2.4
 )
 
 require (
-	github.com/phoenix-tui/phoenix/core v0.2.0 // indirect
-	github.com/phoenix-tui/phoenix/style v0.2.0 // indirect
-	github.com/phoenix-tui/phoenix/terminal v0.2.0 // indirect
+	github.com/phoenix-tui/phoenix/core v0.2.4 // indirect
+	github.com/phoenix-tui/phoenix/style v0.2.4 // indirect
+	github.com/phoenix-tui/phoenix/terminal v0.2.4 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/unilibs/uniwidth v0.2.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect

--- a/examples/hover-highlight/go.mod
+++ b/examples/hover-highlight/go.mod
@@ -15,14 +15,14 @@ replace github.com/phoenix-tui/phoenix/terminal => ../../terminal
 replace github.com/phoenix-tui/phoenix/testing => ../../testing
 
 require (
-	github.com/phoenix-tui/phoenix/mouse v0.1.0-beta.4
-	github.com/phoenix-tui/phoenix/style v0.1.0-beta.4
-	github.com/phoenix-tui/phoenix/tea v0.1.0-beta.4
+	github.com/phoenix-tui/phoenix/mouse v0.2.4
+	github.com/phoenix-tui/phoenix/style v0.2.4
+	github.com/phoenix-tui/phoenix/tea v0.2.4
 )
 
 require (
-	github.com/phoenix-tui/phoenix/core v0.2.0 // indirect
-	github.com/phoenix-tui/phoenix/terminal v0.2.0 // indirect
+	github.com/phoenix-tui/phoenix/core v0.2.4 // indirect
+	github.com/phoenix-tui/phoenix/terminal v0.2.4 // indirect
 	github.com/unilibs/uniwidth v0.2.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/term v0.39.0 // indirect

--- a/examples/wheel-scroll/go.mod
+++ b/examples/wheel-scroll/go.mod
@@ -15,14 +15,14 @@ replace github.com/phoenix-tui/phoenix/style => ../../style
 replace github.com/phoenix-tui/phoenix/testing => ../../testing
 
 require (
-	github.com/phoenix-tui/phoenix/components v0.1.0-beta.4
-	github.com/phoenix-tui/phoenix/tea v0.2.0
+	github.com/phoenix-tui/phoenix/components v0.2.4
+	github.com/phoenix-tui/phoenix/tea v0.2.4
 )
 
 require (
-	github.com/phoenix-tui/phoenix/core v0.2.0 // indirect
-	github.com/phoenix-tui/phoenix/style v0.2.0 // indirect
-	github.com/phoenix-tui/phoenix/terminal v0.2.0 // indirect
+	github.com/phoenix-tui/phoenix/core v0.2.4 // indirect
+	github.com/phoenix-tui/phoenix/style v0.2.4 // indirect
+	github.com/phoenix-tui/phoenix/terminal v0.2.4 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/unilibs/uniwidth v0.2.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -24,11 +24,11 @@ go 1.25.1
 // Require all Phoenix modules
 // This makes the umbrella module useful for users who want all libraries.
 require (
-	github.com/phoenix-tui/phoenix/clipboard v0.2.0
-	github.com/phoenix-tui/phoenix/core v0.2.0
-	github.com/phoenix-tui/phoenix/style v0.2.0
-	github.com/phoenix-tui/phoenix/tea v0.2.0
-	github.com/phoenix-tui/phoenix/terminal v0.2.0
+	github.com/phoenix-tui/phoenix/clipboard v0.2.4
+	github.com/phoenix-tui/phoenix/core v0.2.4
+	github.com/phoenix-tui/phoenix/style v0.2.4
+	github.com/phoenix-tui/phoenix/tea v0.2.4
+	github.com/phoenix-tui/phoenix/terminal v0.2.4
 )
 
 require (

--- a/layout/go.mod
+++ b/layout/go.mod
@@ -3,7 +3,7 @@ module github.com/phoenix-tui/phoenix/layout
 go 1.25.1
 
 require (
-	github.com/phoenix-tui/phoenix/core v0.2.0
+	github.com/phoenix-tui/phoenix/core v0.2.4
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Phoenix TUI Framework - Module Version Bumper
+# Updates all cross-module require versions in go.mod files.
+#
+# Usage: bash scripts/bump-versions.sh v0.2.4
+#
+# This script updates require versions but does NOT run go mod tidy,
+# because the new version doesn't exist on proxy yet (tags not pushed).
+# go.work handles local resolution during development.
+
+set -e
+
+VERSION="$1"
+
+if [ -z "$VERSION" ]; then
+  echo "Error: Version required!"
+  echo ""
+  echo "Usage: $0 <version>"
+  echo "Example: $0 v0.2.4"
+  exit 1
+fi
+
+# Validate version format
+if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?$ ]]; then
+  echo "Error: Invalid version format!"
+  echo "Expected: vX.Y.Z or vX.Y.Z-beta.N or vX.Y.Z-rc.N"
+  echo "Got: $VERSION"
+  exit 1
+fi
+
+echo "Phoenix TUI - Version Bumper"
+echo "============================"
+echo "Target version: $VERSION"
+echo ""
+
+# All Phoenix module import paths
+PHOENIX_MODULES=(
+  "github.com/phoenix-tui/phoenix/clipboard"
+  "github.com/phoenix-tui/phoenix/components"
+  "github.com/phoenix-tui/phoenix/core"
+  "github.com/phoenix-tui/phoenix/layout"
+  "github.com/phoenix-tui/phoenix/mouse"
+  "github.com/phoenix-tui/phoenix/render"
+  "github.com/phoenix-tui/phoenix/style"
+  "github.com/phoenix-tui/phoenix/tea"
+  "github.com/phoenix-tui/phoenix/terminal"
+  "github.com/phoenix-tui/phoenix/testing"
+)
+
+# Find all go.mod files
+GOMOD_FILES=$(find . -name "go.mod" -not -path "./.git/*" | sort)
+
+UPDATED=0
+for gomod in $GOMOD_FILES; do
+  CHANGED=false
+  for mod in "${PHOENIX_MODULES[@]}"; do
+    # Match require lines like: github.com/phoenix-tui/phoenix/core v0.2.0
+    # Also matches with // indirect suffix
+    if grep -q "${mod} v" "$gomod" 2>/dev/null; then
+      # Replace any version with target version (preserve // indirect if present)
+      if sed -i "s|${mod} v[^ ]*|${mod} ${VERSION}|g" "$gomod" 2>/dev/null; then
+        CHANGED=true
+      fi
+    fi
+  done
+  if [ "$CHANGED" = true ]; then
+    echo "  Updated: $gomod"
+    UPDATED=$((UPDATED + 1))
+  fi
+done
+
+echo ""
+echo "Updated $UPDATED go.mod files"
+echo ""
+
+# Verify changes
+echo "Verifying..."
+MISMATCHED=0
+for gomod in $GOMOD_FILES; do
+  for mod in "${PHOENIX_MODULES[@]}"; do
+    # Check for any Phoenix module with wrong version
+    BAD=$(grep "${mod} v" "$gomod" 2>/dev/null | grep -v "${VERSION}" | grep -v "replace" | grep -v "module" || true)
+    if [ -n "$BAD" ]; then
+      echo "  MISMATCH in $gomod: $BAD"
+      MISMATCHED=$((MISMATCHED + 1))
+    fi
+  done
+done
+
+if [ "$MISMATCHED" -gt 0 ]; then
+  echo ""
+  echo "ERROR: $MISMATCHED version mismatches found!"
+  exit 1
+fi
+
+echo "All Phoenix cross-references point to $VERSION"
+echo ""
+echo "Next steps:"
+echo "  1. git add -A && git commit -m \"chore: bump module versions to $VERSION\""
+echo "  2. Push, wait for CI"
+echo "  3. bash scripts/create-release-tags.sh $VERSION"

--- a/style/examples/basic/go.mod
+++ b/style/examples/basic/go.mod
@@ -6,10 +6,10 @@ replace github.com/phoenix-tui/phoenix/style => ../..
 
 replace github.com/phoenix-tui/phoenix/core => ../../../core
 
-require github.com/phoenix-tui/phoenix/style v0.0.0
+require github.com/phoenix-tui/phoenix/style v0.2.4
 
 require (
-	github.com/phoenix-tui/phoenix/core v0.2.0 // indirect
+	github.com/phoenix-tui/phoenix/core v0.2.4 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/unilibs/uniwidth v0.2.0 // indirect
 )

--- a/style/examples/complete/go.mod
+++ b/style/examples/complete/go.mod
@@ -6,10 +6,10 @@ replace github.com/phoenix-tui/phoenix/style => ../..
 
 replace github.com/phoenix-tui/phoenix/core => ../../../core
 
-require github.com/phoenix-tui/phoenix/style v0.0.0
+require github.com/phoenix-tui/phoenix/style v0.2.4
 
 require (
-	github.com/phoenix-tui/phoenix/core v0.2.0 // indirect
+	github.com/phoenix-tui/phoenix/core v0.2.4 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/unilibs/uniwidth v0.2.0 // indirect
 )

--- a/style/go.mod
+++ b/style/go.mod
@@ -3,7 +3,7 @@ module github.com/phoenix-tui/phoenix/style
 go 1.25.1
 
 require (
-	github.com/phoenix-tui/phoenix/core v0.2.0
+	github.com/phoenix-tui/phoenix/core v0.2.4
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/tea/go.mod
+++ b/tea/go.mod
@@ -3,8 +3,8 @@ module github.com/phoenix-tui/phoenix/tea
 go 1.25.1
 
 require (
-	github.com/phoenix-tui/phoenix/terminal v0.2.0
-	github.com/phoenix-tui/phoenix/testing v0.1.0-beta.3
+	github.com/phoenix-tui/phoenix/terminal v0.2.4
+	github.com/phoenix-tui/phoenix/testing v0.2.4
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sys v0.40.0
 	golang.org/x/term v0.39.0

--- a/testing/go.mod
+++ b/testing/go.mod
@@ -2,7 +2,7 @@ module github.com/phoenix-tui/phoenix/testing
 
 go 1.25.1
 
-require github.com/phoenix-tui/phoenix/terminal v0.2.0
+require github.com/phoenix-tui/phoenix/terminal v0.2.4
 
 require (
 	golang.org/x/sys v0.40.0 // indirect


### PR DESCRIPTION
## Summary

- Bump all 15 cross-module `go.mod` references to v0.2.4
- Add `scripts/bump-versions.sh` release automation script

## Test plan

- [ ] CI green on all platforms
- [ ] All go.mod files reference v0.2.4
