### PR TITLE
feat(ci): add Codecov coverage upload via OIDC

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,9 @@ jobs:
   unit-tests:
     name: Unit Tests - ${{ matrix.os }} - Go ${{ matrix.go-version }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -135,6 +138,15 @@ jobs:
         else
           echo "No coverage data found"
         fi
+
+    - name: Upload coverage to Codecov
+      if: matrix.os == 'ubuntu-latest'
+      uses: codecov/codecov-action@v5
+      with:
+        use_oidc: true
+        files: coverage.txt
+        flags: unittests
+        fail_ci_if_error: false
 
   lint:
     name: Lint

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/phoenix-tui/phoenix)](https://goreportcard.com/report/github.com/phoenix-tui/phoenix)
 [![License](https://img.shields.io/github/license/phoenix-tui/phoenix)](https://github.com/phoenix-tui/phoenix/blob/main/LICENSE)
 [![GoDoc](https://pkg.go.dev/badge/github.com/phoenix-tui/phoenix.svg)](https://pkg.go.dev/github.com/phoenix-tui/phoenix)
+[![codecov](https://codecov.io/gh/phoenix-tui/phoenix/branch/main/graph/badge.svg)](https://codecov.io/gh/phoenix-tui/phoenix)
 
 > **Multi-module monorepo** - 10 independent libraries. Full metrics in [CI](https://github.com/phoenix-tui/phoenix/actions).
 


### PR DESCRIPTION
- Add Codecov badge to README.md
- Upload coverage.txt to Codecov from Ubuntu runner via OIDC (no token needed)
- Add `id-token: write` permission for OIDC authentication
- `fail_ci_if_error: false` — non-blocking during initial setup